### PR TITLE
Fix MQTT message payload comparison

### DIFF
--- a/notifications.py
+++ b/notifications.py
@@ -13,7 +13,7 @@ mqtt = Mqtt()
 def handle_messages(client, userdata, message):
     print('Received message on topic {}: {}'
           .format(message.topic, message.payload.decode()))
-    if message == 'hi':
+    if message.payload.decode() == 'hi':
         print('== THIS IS NOT JOKE NO HI HERE ==')
 
 

--- a/notifications.py
+++ b/notifications.py
@@ -11,9 +11,9 @@ mqtt = Mqtt()
 
 @mqtt.on_message()
 def handle_messages(client, userdata, message):
-    print('Received message on topic {}: {}'
-          .format(message.topic, message.payload.decode()))
-    if message.payload.decode() == 'hi':
+    payload_text = message.payload.decode()
+    print('Received message on topic {}: {}'.format(message.topic, payload_text))
+    if payload_text == 'hi':
         print('== THIS IS NOT JOKE NO HI HERE ==')
 
 


### PR DESCRIPTION
## Summary
- correct MQTT message payload decoding in notification handler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68420ac00b888327a2289f2cb31b65d5

## Summary by Sourcery

Bug Fixes:
- Compare decoded payload string instead of the message object in the MQTT notification handler