### PR TITLE
Fix remember me checkbox

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -25,7 +25,7 @@
             </div>
             <div class="field">
                 <label class="checkbox">
-                    <input type="checkbox">
+                    <input type="checkbox" name="remember">
                     Remember me
                 </label>
             </div>


### PR DESCRIPTION
## Summary
- add `name="remember"` to the checkbox in login template
- login route already reads this value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ba4452e4832792a1ecbe64572c52

## Summary by Sourcery

Bug Fixes:
- Add name="remember" to the login form checkbox to ensure the option is included in form data