### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/action_devices.py
+++ b/action_devices.py
@@ -298,7 +298,8 @@ def request_sync(api_key, agent_user_id):
         response = requests.post(url, json=data)
 
         print(f'\nRequests Code: {requests.codes["ok"]}\nResponse Code: {response.status_code}')
-        print(f'\nResponse: {response.text}')
+        # Do not log full response body to avoid leaking sensitive information.
+        print('\nResponse body omitted from logs for security reasons')
 
         return response.status_code == requests.codes['ok']
     except Exception as e:

--- a/app.py
+++ b/app.py
@@ -163,7 +163,8 @@ if not FULL_FEATURES:
                 state_result = report_state()
                 return {'sync_requested': True, 'success': success, 'state_report': state_result}
             except Exception as e:
-                return {'error': str(e)}, 500
+                app.logger.exception("Error during /sync endpoint processing")
+                return {'error': 'Internal server error'}, 500
 
     except ImportError as e:
         print(f"Could not import action_devices: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/DaTiC0/smart-google/security/code-scanning/10](https://github.com/DaTiC0/smart-google/security/code-scanning/10)

General approach: Avoid logging untrusted or potentially sensitive response bodies, especially when they are associated with secrets such as API keys. Keep only minimal, non-sensitive information in logs, such as HTTP status codes or high-level error messages, and do not log the API key, full URL, or raw body.

Best concrete fix here: In `action_devices.py`’s `request_sync` function, keep the status code logging (which is not sensitive) but stop logging the full `response.text`. If needed for troubleshooting, we can log a truncated or generic message that does not contain the raw body. This addresses all three alert variants because they all flow through `response.text` logging. We do not need new imports or structural changes; just adjust the `print` statements.

Specific changes:

- File: `action_devices.py`
  - In `request_sync`:
    - Keep the line logging `requests.codes["ok"]` and `response.status_code`.
    - Replace the line `print(f'\nResponse: {response.text}')` with a safer message that does not include the body, e.g. `print('\nResponse body omitted from logs for security reasons')` or remove it entirely. I’ll keep a generic note so operators know a response was received.

No other files need code changes for this issue, because the vulnerability is at the sink in `request_sync`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Avoid logging full HTTP response bodies in device sync requests to reduce the risk of exposing sensitive information in logs.

Bug Fixes:
- Prevent clear-text logging of potentially sensitive response data in the request_sync flow.

Enhancements:
- Replace detailed response body logging with a generic non-sensitive log message in request_sync.