### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/path-safety.yml
+++ b/.github/workflows/path-safety.yml
@@ -1,5 +1,8 @@
 name: Path safety
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 gunicorn==25.1.0
-Flask==1.1.2
+Flask>=2.0.3,<3.0.0
 Flask-MQTT==1.1.1
 Flask-OAuthlib==0.9.6
-Flask-SQLAlchemy==2.5.1
-SQLAlchemy==1.4.47
-Werkzeug>=2.0.0,<2.4.0
+Flask-SQLAlchemy>=3.0.0,<4.0.0
+SQLAlchemy>=1.4.18,<3.0.0
+Werkzeug>=2.3.7,<3.0.0
 Jinja2>=3.0.0,<4.0.0
 MarkupSafe>=2.0.0,<3.0.0
 itsdangerous>=2.0.0,<3.0.0
@@ -16,4 +16,4 @@ requests-oauthlib
 requests>=2.31.0
 cryptography>=41.0.0
 python-dotenv==1.0.0
-Flask-Login==0.4.1
+Flask-Login>=0.6.0,<1.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/DaTiC0/smart-google/security/code-scanning/19](https://github.com/DaTiC0/smart-google/security/code-scanning/19)

In general, the fix is to explicitly define a `permissions` block for the workflow or the specific job, granting only the minimal scopes required. Since this job only checks out the repository and runs a script, it only needs read access to repository contents; no write permissions or other scopes (issues, pull-requests, actions, etc.) are necessary.

The best minimal fix here is to add a `permissions` block at the top (root) level of `.github/workflows/path-safety.yml`, alongside `name` and `on`. This will apply to all jobs in the workflow that do not override permissions individually. We'll set `contents: read`, which corresponds to a read-only token for repository contents and matches CodeQL’s suggested starting point. No changes to steps, actions versions, or scripts are needed, and no additional imports or external libraries are involved.

Concretely: in `.github/workflows/path-safety.yml`, after the `name: Path safety` line (line 1) and before the `on:` block (currently line 3), insert:

```yaml
permissions:
  contents: read
```

This ensures the GITHUB_TOKEN used by `actions/checkout` is restricted to read-only contents access, preserving all existing behavior while satisfying least-privilege requirements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Constrain workflow token permissions and modernize Python web dependency versions.

Build:
- Relax and update version constraints for Flask, SQLAlchemy, Werkzeug, Flask-SQLAlchemy, and Flask-Login in requirements.txt to support newer compatible releases.

CI:
- Add a minimal read-only contents permission block to the path-safety GitHub Actions workflow to satisfy least-privilege and code scanning requirements.