### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-main-to-container.yml
+++ b/.github/workflows/sync-main-to-container.yml
@@ -5,6 +5,8 @@ on:
       - main
 jobs:
   merge-branch:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/DaTiC0/smart-google/security/code-scanning/18](https://github.com/DaTiC0/smart-google/security/code-scanning/18)

To fix the problem, add an explicit `permissions` block defining the least privileges needed for this workflow. This job merges `main` into `container` and pushes back to the repository, so it needs write access to repository contents via `GITHUB_TOKEN`. It does not appear to need other scopes (e.g., no issues, PRs, or packages operations are present), so we can restrict it to `contents: write`.

The best way to fix this without changing functionality is to add a `permissions` block at the job level under `merge-branch:`. That way, only this job is granted `contents: write`. Specifically, in `.github/workflows/sync-main-to-container.yml`, under `jobs:`, after the `merge-branch:` line and before `runs-on: ubuntu-latest`, add:

```yaml
    permissions:
      contents: write
```

No additional imports, methods, or definitions are required, since this is a YAML GitHub Actions workflow file; the `permissions` key is standard syntax.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Add an explicit permissions block granting contents: write to the merge-branch job in the sync-main-to-container GitHub Actions workflow to address a code scanning alert about missing permissions configuration.