### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -3,6 +3,9 @@
 
 name: Python application
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/DaTiC0/smart-google/security/code-scanning/17](https://github.com/DaTiC0/smart-google/security/code-scanning/17)

To fix the problem, explicitly define `permissions` for the workflow or the `build` job so that the `GITHUB_TOKEN` has only the minimal required access. Since this workflow only reads repository contents and does not modify issues, PRs, releases, etc., `contents: read` is sufficient as a baseline. Placing `permissions` at the root level (alongside `name` and `on`) will apply it to all jobs in the workflow, which is appropriate here as there is only one job.

Concretely, edit `.github/workflows/python-app.yml` and add a `permissions` block near the top of the file, after the `name:` line and before the `on:` block. The new block should be:

```yaml
permissions:
  contents: read
```

No imports or additional methods are needed, as this is purely a YAML configuration change within the existing workflow file. Existing functionality (checkout, setup-python, pip install, flake8, pytest) will continue to work, because they only require read access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Define explicit minimal GitHub token permissions (contents: read) for the python-app workflow to address code scanning alerts.