### PR TITLE
build: add psycopg2-binary for PostgreSQL support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ six==1.14.0
 firebase_admin==6.5.0
 google-auth>=2.22.0
 PyMySQL==1.1.1
+psycopg2-binary==2.9.12
 requests-oauthlib
 requests>=2.31.0
 cryptography>=41.0.0


### PR DESCRIPTION
Adds the PostgreSQL database driver to requirements.txt to support production environments and local testing with Neon.