### PR TITLE
feat: Upgrade Python version to 3.12 in Dockerfile and refactor SQLAlchemy queries for user and client retrieval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.8.16-slim
+FROM python:3.12-slim
 
 # Allow statements and log messages to immediately appear in the Knative logs
-ENV PYTHONUNBUFFERED True
+ENV PYTHONUNBUFFERED=True
 
 # Copy local code to the container image.
-ENV APP_HOME /app
+ENV APP_HOME=/app
 WORKDIR $APP_HOME
 
 # Install production dependencies.
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . ./
 
 # Expose port 8080 to the world outside this container
-ENV PORT 8080
+ENV PORT=8080
 EXPOSE $PORT
 
 # Run the web service on container startup. Here we use the gunicorn
@@ -27,6 +27,6 @@ EXPOSE $PORT
 # For environments with multiple CPU cores, increase the number of workers
 # to be equal to the cores available.
 # Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 app:app
+CMD ["sh", "-c", "exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 app:app"]
 
 # docker run --env-file=env_file_name

--- a/auth.py
+++ b/auth.py
@@ -22,7 +22,7 @@ def login_post():
     password = request.form.get('password')
     remember = bool(request.form.get('remember'))
 
-    user = db.session.execute(select(User).filter_by(email=email)).scalar_one_or_none()
+    user = db.session.scalars(select(User).filter_by(email=email)).first()
 
     if not user or not check_password_hash(user.password, password):
         flash('Please check your login details and try again.')
@@ -44,7 +44,7 @@ def signup_post():
     name = request.form.get('name')
     password = request.form.get('password')
     # get user from database
-    user = db.session.execute(select(User).filter_by(email=email)).scalar_one_or_none()
+    user = db.session.scalars(select(User).filter_by(email=email)).first()
     if user:
         flash('This Mail is used by another Person')
         return redirect(url_for('auth.signup'))

--- a/auth.py
+++ b/auth.py
@@ -4,6 +4,7 @@
 from flask import Blueprint, render_template, redirect, url_for, request, flash
 from werkzeug.security import generate_password_hash, check_password_hash
 from flask_login import login_user, logout_user, login_required
+from sqlalchemy import select
 from models import db, User
 
 
@@ -21,7 +22,7 @@ def login_post():
     password = request.form.get('password')
     remember = bool(request.form.get('remember'))
 
-    user = User.query.filter_by(email=email).first()
+    user = db.session.execute(select(User).filter_by(email=email)).scalar_one_or_none()
 
     if not user or not check_password_hash(user.password, password):
         flash('Please check your login details and try again.')
@@ -43,13 +44,13 @@ def signup_post():
     name = request.form.get('name')
     password = request.form.get('password')
     # get user from database
-    user = User.query.filter_by(email=email).first()
+    user = db.session.execute(select(User).filter_by(email=email)).scalar_one_or_none()
     if user:
         flash('This Mail is used by another Person')
         return redirect(url_for('auth.signup'))
     # If not User found Create new
     new_user = User(email=email, name=name,
-                    password=generate_password_hash(password, method='sha256'))
+                    password=generate_password_hash(password))
     db.session.add(new_user)
     db.session.commit()
 

--- a/models.py
+++ b/models.py
@@ -10,7 +10,7 @@ class User(UserMixin, db.Model):
     username = db.Column(db.String(40), unique=True)  # this will be removed
     #
     email = db.Column(db.String(100), unique=True)
-    password = db.Column(db.String(100))
+    password = db.Column(db.String(255))
     name = db.Column(db.String(1000))
 
 

--- a/my_oauth.py
+++ b/my_oauth.py
@@ -78,12 +78,13 @@ def load_token(access_token=None, refresh_token=None):
 def save_token(token, request, *args, **kwargs):
     logger.debug("token setter")
     # make sure that every client has only one token connected to a user
-    for t in db.session.scalars(
+    existing_tokens = db.session.execute(
         select(Token).filter_by(
             client_id=request.client.client_id,
             user_id=request.user.id,
         )
-    ):
+    ).scalars()
+    for t in existing_tokens:
         db.session.delete(t)
 
     expires_in = token.pop('expires_in')

--- a/my_oauth.py
+++ b/my_oauth.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from flask_oauthlib.provider import OAuth2Provider
 from flask import session
+from sqlalchemy import select
 from models import db
 from models import Client, Token, Grant, User
 
@@ -16,7 +17,7 @@ oauth = OAuth2Provider()
 def get_current_user():
     if 'id' in session:
         uid = session['id']
-        user = User.query.get(uid)
+        user = db.session.get(User, uid)
         logger.debug("Current user: %s", user)
         return user
     return None
@@ -26,7 +27,9 @@ def get_current_user():
 def load_client(client_id):
     logger.debug("get client")
     logger.debug("client_id: %s", client_id)
-    client = Client.query.filter_by(client_id=client_id).first()
+    client = db.session.execute(
+        select(Client).filter_by(client_id=client_id)
+    ).scalar_one_or_none()
     logger.debug("Client: %s", client)
     return client
 
@@ -34,7 +37,9 @@ def load_client(client_id):
 @oauth.grantgetter
 def load_grant(client_id, code):
     logger.debug("grant getter")
-    return Grant.query.filter_by(client_id=client_id, code=code).first()
+    return db.session.execute(
+        select(Grant).filter_by(client_id=client_id, code=code)
+    ).scalar_one_or_none()
 
 
 @oauth.grantsetter
@@ -60,18 +65,24 @@ def save_grant(client_id, code, request, *args, **kwargs):
 def load_token(access_token=None, refresh_token=None):
     logger.debug("token getter")
     if access_token:
-        return Token.query.filter_by(access_token=access_token).first()
+        return db.session.execute(
+            select(Token).filter_by(access_token=access_token)
+        ).scalar_one_or_none()
     if refresh_token:
-        return Token.query.filter_by(refresh_token=refresh_token).first()
+        return db.session.execute(
+            select(Token).filter_by(refresh_token=refresh_token)
+        ).scalar_one_or_none()
 
 
 @oauth.tokensetter
 def save_token(token, request, *args, **kwargs):
     logger.debug("token setter")
-    toks = Token.query.filter_by(
-        client_id=request.client.client_id,
-        user_id=request.user.id
-    )
+    toks = db.session.execute(
+        select(Token).filter_by(
+            client_id=request.client.client_id,
+            user_id=request.user.id,
+        )
+    ).scalars().all()
     logger.debug("Existing tokens: %s", toks)
     # make sure that every client has only one token connected to a user
     for t in toks:

--- a/my_oauth.py
+++ b/my_oauth.py
@@ -77,15 +77,13 @@ def load_token(access_token=None, refresh_token=None):
 @oauth.tokensetter
 def save_token(token, request, *args, **kwargs):
     logger.debug("token setter")
-    toks = db.session.scalars(
+    # make sure that every client has only one token connected to a user
+    for t in db.session.scalars(
         select(Token).filter_by(
             client_id=request.client.client_id,
             user_id=request.user.id,
         )
-    )
-    logger.debug("Existing tokens: %s", toks)
-    # make sure that every client has only one token connected to a user
-    for t in toks:
+    ):
         db.session.delete(t)
 
     expires_in = token.pop('expires_in')

--- a/my_oauth.py
+++ b/my_oauth.py
@@ -27,9 +27,9 @@ def get_current_user():
 def load_client(client_id):
     logger.debug("get client")
     logger.debug("client_id: %s", client_id)
-    client = db.session.execute(
+    client = db.session.scalars(
         select(Client).filter_by(client_id=client_id)
-    ).scalar_one_or_none()
+    ).first()
     logger.debug("Client: %s", client)
     return client
 
@@ -37,9 +37,9 @@ def load_client(client_id):
 @oauth.grantgetter
 def load_grant(client_id, code):
     logger.debug("grant getter")
-    return db.session.execute(
+    return db.session.scalars(
         select(Grant).filter_by(client_id=client_id, code=code)
-    ).scalar_one_or_none()
+    ).first()
 
 
 @oauth.grantsetter
@@ -65,24 +65,24 @@ def save_grant(client_id, code, request, *args, **kwargs):
 def load_token(access_token=None, refresh_token=None):
     logger.debug("token getter")
     if access_token:
-        return db.session.execute(
+        return db.session.scalars(
             select(Token).filter_by(access_token=access_token)
-        ).scalar_one_or_none()
+        ).first()
     if refresh_token:
-        return db.session.execute(
+        return db.session.scalars(
             select(Token).filter_by(refresh_token=refresh_token)
-        ).scalar_one_or_none()
+        ).first()
 
 
 @oauth.tokensetter
 def save_token(token, request, *args, **kwargs):
     logger.debug("token setter")
-    toks = db.session.execute(
+    toks = db.session.scalars(
         select(Token).filter_by(
             client_id=request.client.client_id,
             user_id=request.user.id,
         )
-    ).scalars().all()
+    )
     logger.debug("Existing tokens: %s", toks)
     # make sure that every client has only one token connected to a user
     for t in toks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,12 @@
 gunicorn==25.3.0
-Flask>=2.0.3,<3.0.0
-Flask-MQTT==1.1.1
+Flask>=3.1.3,<4.0.0
+Flask-MQTT>=1.3.0,<2.0.0
 Flask-OAuthlib==0.9.6
-Flask-SQLAlchemy>=3.0.0,<4.0.0
-SQLAlchemy>=1.4.18,<3.0.0
-Werkzeug>=2.3.7,<3.0.0
-Jinja2>=3.0.0,<4.0.0
-MarkupSafe>=2.0.0,<3.0.0
-itsdangerous>=2.0.0,<3.0.0
+Flask-SQLAlchemy>=3.1.0,<4.0.0
+SQLAlchemy>=2.0.16,<3.0.0
+Werkzeug>=3.1.0,<4.0.0
+Jinja2>=3.1.2,<4.0.0
+itsdangerous>=2.2.0,<3.0.0
 six==1.14.0
 firebase_admin==6.5.0
 google-auth>=2.22.0
@@ -17,4 +16,4 @@ requests-oauthlib
 requests>=2.31.0
 cryptography>=41.0.0
 python-dotenv==1.0.0
-Flask-Login>=0.6.0,<1.0.0
+Flask-Login>=0.6.3,<1.0.0

--- a/routes.py
+++ b/routes.py
@@ -2,7 +2,6 @@
 # Code By DaTi_Co
 
 import logging
-from typing import Any, cast
 from flask import Blueprint, current_app, request, jsonify, redirect, render_template, make_response, url_for
 from flask_login import login_required, current_user
 from sqlalchemy import select
@@ -45,7 +44,7 @@ def access_token():
     return {'version': '0.1.0'}
 
 
-@bp.route('/oauth/authorize', methods=['GET', 'POST'])
+@bp.route('/oauth/authorize', methods=['GET', 'POST'])  # pyright: ignore[reportArgumentType]
 # Both GET (render consent page) and POST (handle form submission) are required
 # by the OAuth2 Authorization Code flow and the @oauth.authorize_handler decorator.
 @oauth.authorize_handler
@@ -55,9 +54,9 @@ def authorize(*args, **kwargs):
         return redirect('/')
     if request.method == 'GET':
         client_id = kwargs.get('client_id')
-        client = db.session.execute(
+        client = db.session.scalars(
             select(Client).filter_by(client_id=client_id)
-        ).scalar_one_or_none()
+        ).first()
         if client is None:
             return redirect('/')
         kwargs['client'] = client
@@ -65,7 +64,7 @@ def authorize(*args, **kwargs):
         return render_template('authorize.html', **kwargs)
 
     confirm = request.form.get('confirm', 'no')
-    return cast(Any, confirm == 'yes')
+    return confirm == 'yes'
 
 
 @bp.route('/api/me')

--- a/routes.py
+++ b/routes.py
@@ -2,10 +2,12 @@
 # Code By DaTi_Co
 
 import logging
+from typing import Any, cast
 from flask import Blueprint, current_app, request, jsonify, redirect, render_template, make_response, url_for
 from flask_login import login_required, current_user
+from sqlalchemy import select
 from action_devices import onSync, report_state, request_sync, actions, rquery
-from models import Client
+from models import Client, db
 from my_oauth import get_current_user, oauth
 from notifications import is_mqtt_connected
 
@@ -53,7 +55,9 @@ def authorize(*args, **kwargs):
         return redirect('/')
     if request.method == 'GET':
         client_id = kwargs.get('client_id')
-        client = Client.query.filter_by(client_id=client_id).first()
+        client = db.session.execute(
+            select(Client).filter_by(client_id=client_id)
+        ).scalar_one_or_none()
         if client is None:
             return redirect('/')
         kwargs['client'] = client
@@ -61,7 +65,7 @@ def authorize(*args, **kwargs):
         return render_template('authorize.html', **kwargs)
 
     confirm = request.form.get('confirm', 'no')
-    return confirm == 'yes'
+    return cast(Any, confirm == 'yes')
 
 
 @bp.route('/api/me')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -108,6 +108,29 @@ class AuthTests(unittest.TestCase):
         self.assertEqual(resp2.status_code, 200)
         self.assertIn('Profile', resp2.get_data(as_text=True))
 
+    def test_password_hash_fits_schema_length(self):
+        self.client.post('/signup', data={'email': 'a@b.com', 'name': 'A', 'password': 'pass'})
+        with flask_app.app_context():
+            user = db.session.execute(select(User).filter_by(email='a@b.com')).scalar_one_or_none()
+            self.assertIsNotNone(user)
+            self.assertLessEqual(len(user.password), 255)
+
+
+class OAuthEndpointTests(unittest.TestCase):
+    def setUp(self):
+        flask_app.config.update(TESTING=True)
+        self.client = flask_app.test_client()
+
+    def test_oauth_routes_smoke(self):
+        authorize_resp = self.client.get('/oauth/authorize', follow_redirects=False)
+        self.assertEqual(authorize_resp.status_code, 302)
+
+        token_resp = self.client.post('/oauth/token', data={'grant_type': 'client_credentials'})
+        self.assertEqual(token_resp.status_code, 401)
+
+        me_resp = self.client.get('/api/me')
+        self.assertEqual(me_resp.status_code, 401)
+
 
 class DeviceEndpointTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

- What changed?
- Why was it needed?

## Validation

- [ ] Local checks passed (`make test`)
- [ ] Runtime check done where relevant (`make health`)
- [ ] CI checks are green

## AI-Assisted Review (if applicable)

- [ ] I used AI assistance for parts of this change
- [ ] I manually reviewed all AI-generated code
- [ ] I verified no secrets/credentials were added

## Risk & Rollback

- Risk level: Low / Medium / High
- Rollback plan (if needed):

## Summary by Sourcery

Upgrade runtime and dependencies to Python 3.12-compatible versions and modernize database access patterns.

Bug Fixes:
- Use SQLAlchemy 2.x-style session APIs to safely retrieve users, clients, grants, and tokens, preventing reliance on deprecated query patterns.

Enhancements:
- Refactor SQLAlchemy queries to use db.session with select() and scalar helpers for user, client, grant, and token retrieval.
- Simplify password hashing by using the default hash method in generate_password_hash.
- Clarify authorization response handling by explicitly casting the confirmation result.

Build:
- Bump Python base image in Dockerfile to 3.12-slim and use JSON-form CMD for gunicorn startup.
- Update Flask, Flask-MQTT, Flask-SQLAlchemy, SQLAlchemy, Werkzeug, Jinja2, itsdangerous, and Flask-Login versions to ranges compatible with Python 3.12 and SQLAlchemy 2.x.