### PR TITLE
feat: migrate OAuth provider from Flask-OAuthlib to Authlib (Phase 2)

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ from flask_login import LoginManager
 from firebase_admin import credentials, initialize_app, get_app
 from auth import auth
 from models import User, db
-from my_oauth import oauth
+from my_oauth import init_oauth
 from notifications import mqtt
 from routes import bp
 
@@ -51,6 +51,10 @@ def _init_firebase(flask_app: Flask) -> None:
 app = Flask(__name__, template_folder='templates')
 app.config.from_object(_get_config_object())
 
+if app.config.get('ENV') != 'production':
+    # Authlib requires HTTPS by default; allow HTTP for local/dev/test only.
+    os.environ.setdefault('AUTHLIB_INSECURE_TRANSPORT', '1')
+
 logger.info('ENV is set to: %s', app.config.get('ENV'))
 logger.info('Agent USER.ID: %s', app.config.get('AGENT_USER_ID'))
 
@@ -69,7 +73,7 @@ except Exception as e:
 db.init_app(app)
 
 # OAuth2 Authorisation
-oauth.init_app(app)
+init_oauth(app)
 
 # Flask Login
 login_manager = LoginManager()

--- a/models.py
+++ b/models.py
@@ -1,4 +1,5 @@
 # models.py
+from datetime import datetime, timezone
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import UserMixin
 
@@ -45,6 +46,49 @@ class Client(db.Model):
             return self._default_scopes.split()
         return []
 
+    @property
+    def grant_types(self):
+        return ['authorization_code', 'refresh_token']
+
+    @property
+    def response_types(self):
+        return ['code']
+
+    @property
+    def token_endpoint_auth_method(self):
+        return 'client_secret_post'
+
+    def check_client_secret(self, client_secret):
+        return self.client_secret == client_secret
+
+    def check_endpoint_auth_method(self, method, endpoint):
+        if endpoint == 'token':
+            return method in ('client_secret_basic', 'client_secret_post')
+        return True
+
+    def check_response_type(self, response_type):
+        return response_type in self.response_types
+
+    def check_grant_type(self, grant_type):
+        return grant_type in self.grant_types
+
+    def check_redirect_uri(self, redirect_uri):
+        return redirect_uri in self.redirect_uris
+
+    def get_default_redirect_uri(self):
+        return self.default_redirect_uri
+
+    def get_allowed_scope(self, scope):
+        if not scope:
+            return ''
+        if not self.default_scopes:
+            return scope
+        requested = set(scope.split())
+        allowed = set(self.default_scopes)
+        if requested.issubset(allowed):
+            return scope
+        return None
+
 
 class Grant(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -74,6 +118,18 @@ class Grant(db.Model):
             return self._scopes.split()
         return []
 
+    def get_redirect_uri(self):
+        return self.redirect_uri
+
+    def get_scope(self):
+        return self._scopes or ''
+
+    def is_expired(self):
+        if self.expires is None:
+            return False
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        return self.expires < now
+
 
 class Token(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -99,3 +155,15 @@ class Token(db.Model):
         if self._scopes:
             return self._scopes.split()
         return []
+
+    def get_scope(self):
+        return self._scopes or ''
+
+    def is_revoked(self):
+        return False
+
+    def is_expired(self):
+        if self.expires is None:
+            return False
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        return self.expires < now

--- a/models.py
+++ b/models.py
@@ -63,7 +63,7 @@ class Client(db.Model):
 
     def check_endpoint_auth_method(self, method, endpoint):
         if endpoint == 'token':
-            return method in ('client_secret_basic', 'client_secret_post')
+            return method in ('client_secret_basic', self.token_endpoint_auth_method)
         return True
 
     def check_response_type(self, response_type):
@@ -160,7 +160,7 @@ class Token(db.Model):
         return self._scopes or ''
 
     def is_revoked(self):
-        return False
+        return not bool(self.access_token)
 
     def is_expired(self):
         if self.expires is None:

--- a/models.py
+++ b/models.py
@@ -73,7 +73,9 @@ class Client(db.Model):
         return grant_type in self.grant_types
 
     def check_redirect_uri(self, redirect_uri):
-        return redirect_uri in self.redirect_uris
+        if not redirect_uri:
+            return False
+        return redirect_uri in set(self.redirect_uris)
 
     def get_default_redirect_uri(self):
         return self.default_redirect_uri
@@ -81,8 +83,6 @@ class Client(db.Model):
     def get_allowed_scope(self, scope):
         if not scope:
             return ''
-        if not self.default_scopes:
-            return scope
         requested = set(scope.split())
         allowed = set(self.default_scopes)
         if requested.issubset(allowed):

--- a/my_oauth.py
+++ b/my_oauth.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 oauth = AuthorizationServer()
 require_oauth = ResourceProtector()
 _oauth_configured = False
+AUTHORIZATION_CODE_EXPIRES_IN = 100
+DEFAULT_ACCESS_TOKEN_EXPIRES_IN = 3600
 
 
 def _utcnow_naive():
@@ -53,7 +55,18 @@ def save_token(token_data, request):
     for t in existing_tokens:
         db.session.delete(t)
 
-    expires_in = int(token_data.get('expires_in', 0))
+    raw_expires_in = token_data.get('expires_in')
+    try:
+        expires_in = int(raw_expires_in)
+        if expires_in <= 0:
+            raise ValueError('expires_in must be positive')
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid token expires_in=%r; defaulting to %s seconds",
+            raw_expires_in,
+            DEFAULT_ACCESS_TOKEN_EXPIRES_IN,
+        )
+        expires_in = DEFAULT_ACCESS_TOKEN_EXPIRES_IN
     expires = _utcnow_naive() + timedelta(seconds=expires_in)
 
     tok = Token(
@@ -74,7 +87,7 @@ def save_token(token_data, request):
 class AuthorizationCodeGrant(grants.AuthorizationCodeGrant):
     def save_authorization_code(self, code, request):
         logger.debug("save authorization code")
-        expires = _utcnow_naive() + timedelta(seconds=100)
+        expires = _utcnow_naive() + timedelta(seconds=AUTHORIZATION_CODE_EXPIRES_IN)
         grant = Grant(
             client_id=request.client.client_id,
             code=code,
@@ -124,9 +137,12 @@ class RefreshTokenGrant(grants.RefreshTokenGrant):
 
 class MyBearerTokenValidator(BearerTokenValidator):
     def authenticate_token(self, token_string):
-        return db.session.scalars(
+        token = db.session.scalars(
             select(Token).filter_by(access_token=token_string)
         ).first()
+        if token and (token.is_expired() or token.is_revoked()):
+            return None
+        return token
 
 
 def init_oauth(app):

--- a/my_oauth.py
+++ b/my_oauth.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 oauth = AuthorizationServer()
 require_oauth = ResourceProtector()
-_oauth_configured = False
 AUTHORIZATION_CODE_EXPIRES_IN = 100
 DEFAULT_ACCESS_TOKEN_EXPIRES_IN = 3600
 
@@ -127,11 +126,11 @@ class RefreshTokenGrant(grants.RefreshTokenGrant):
             return token
         return None
 
-    def authenticate_user(self, credential):
-        return credential.user
+    def authenticate_user(self, refresh_token):
+        return refresh_token.user
 
-    def revoke_old_credential(self, credential):
-        db.session.delete(credential)
+    def revoke_old_credential(self, refresh_token):
+        db.session.delete(refresh_token)
         db.session.commit()
 
 
@@ -146,12 +145,11 @@ class MyBearerTokenValidator(BearerTokenValidator):
 
 
 def init_oauth(app):
-    global _oauth_configured
-    if _oauth_configured:
+    if app.extensions.get('authlib_oauth_configured'):
         return
 
     oauth.init_app(app, query_client=load_client, save_token=save_token)
     oauth.register_grant(AuthorizationCodeGrant)
     oauth.register_grant(RefreshTokenGrant)
     require_oauth.register_token_validator(MyBearerTokenValidator())
-    _oauth_configured = True
+    app.extensions['authlib_oauth_configured'] = True

--- a/my_oauth.py
+++ b/my_oauth.py
@@ -3,7 +3,9 @@
 # OAuth2
 import logging
 from datetime import datetime, timedelta, timezone
-from flask_oauthlib.provider import OAuth2Provider
+from authlib.integrations.flask_oauth2 import AuthorizationServer, ResourceProtector
+from authlib.oauth2.rfc6749 import grants
+from authlib.oauth2.rfc6750 import BearerTokenValidator
 from flask import session
 from sqlalchemy import select
 from models import db
@@ -11,7 +13,13 @@ from models import Client, Token, Grant, User
 
 logger = logging.getLogger(__name__)
 
-oauth = OAuth2Provider()
+oauth = AuthorizationServer()
+require_oauth = ResourceProtector()
+_oauth_configured = False
+
+
+def _utcnow_naive():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 def get_current_user():
@@ -23,7 +31,6 @@ def get_current_user():
     return None
 
 
-@oauth.clientgetter
 def load_client(client_id):
     logger.debug("get client")
     logger.debug("client_id: %s", client_id)
@@ -34,48 +41,7 @@ def load_client(client_id):
     return client
 
 
-@oauth.grantgetter
-def load_grant(client_id, code):
-    logger.debug("grant getter")
-    return db.session.scalars(
-        select(Grant).filter_by(client_id=client_id, code=code)
-    ).first()
-
-
-@oauth.grantsetter
-def save_grant(client_id, code, request, *args, **kwargs):
-    # decide the expires time yourself
-    logger.debug("save grant")
-    expires = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=100)
-    grant = Grant(
-        client_id=client_id,
-        code=code['code'],
-        redirect_uri=request.redirect_uri,
-        _scopes=' '.join(request.scopes),
-        user=get_current_user(),
-        expires=expires
-    )
-    logger.debug("Grant created: %s", grant)
-    db.session.add(grant)
-    db.session.commit()
-    return grant
-
-
-@oauth.tokengetter
-def load_token(access_token=None, refresh_token=None):
-    logger.debug("token getter")
-    if access_token:
-        return db.session.scalars(
-            select(Token).filter_by(access_token=access_token)
-        ).first()
-    if refresh_token:
-        return db.session.scalars(
-            select(Token).filter_by(refresh_token=refresh_token)
-        ).first()
-
-
-@oauth.tokensetter
-def save_token(token, request, *args, **kwargs):
+def save_token(token_data, request):
     logger.debug("token setter")
     # make sure that every client has only one token connected to a user
     existing_tokens = db.session.execute(
@@ -87,14 +53,14 @@ def save_token(token, request, *args, **kwargs):
     for t in existing_tokens:
         db.session.delete(t)
 
-    expires_in = token.pop('expires_in')
-    expires = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=expires_in)
+    expires_in = int(token_data.get('expires_in', 0))
+    expires = _utcnow_naive() + timedelta(seconds=expires_in)
 
     tok = Token(
-        access_token=token['access_token'],
-        refresh_token=token['refresh_token'],
-        token_type=token['token_type'],
-        _scopes=token['scope'],
+        access_token=token_data['access_token'],
+        refresh_token=token_data.get('refresh_token'),
+        token_type=token_data.get('token_type', 'Bearer'),
+        _scopes=token_data.get('scope', ''),
         expires=expires,
         client_id=request.client.client_id,
         user_id=request.user.id,
@@ -103,3 +69,73 @@ def save_token(token, request, *args, **kwargs):
     db.session.add(tok)
     db.session.commit()
     return tok
+
+
+class AuthorizationCodeGrant(grants.AuthorizationCodeGrant):
+    def save_authorization_code(self, code, request):
+        logger.debug("save authorization code")
+        expires = _utcnow_naive() + timedelta(seconds=100)
+        grant = Grant(
+            client_id=request.client.client_id,
+            code=code,
+            redirect_uri=request.redirect_uri,
+            _scopes=request.scope or '',
+            user=request.user,
+            expires=expires,
+        )
+        db.session.add(grant)
+        db.session.commit()
+        return grant
+
+    def query_authorization_code(self, code, client):
+        grant = db.session.scalars(
+            select(Grant).filter_by(client_id=client.client_id, code=code)
+        ).first()
+        if grant and not grant.is_expired():
+            return grant
+        return None
+
+    def delete_authorization_code(self, authorization_code):
+        db.session.delete(authorization_code)
+        db.session.commit()
+
+    def authenticate_user(self, authorization_code):
+        return authorization_code.user
+
+
+class RefreshTokenGrant(grants.RefreshTokenGrant):
+    INCLUDE_NEW_REFRESH_TOKEN = True
+
+    def authenticate_refresh_token(self, refresh_token):
+        token = db.session.scalars(
+            select(Token).filter_by(refresh_token=refresh_token)
+        ).first()
+        if token and not token.is_expired() and not token.is_revoked():
+            return token
+        return None
+
+    def authenticate_user(self, credential):
+        return credential.user
+
+    def revoke_old_credential(self, credential):
+        db.session.delete(credential)
+        db.session.commit()
+
+
+class MyBearerTokenValidator(BearerTokenValidator):
+    def authenticate_token(self, token_string):
+        return db.session.scalars(
+            select(Token).filter_by(access_token=token_string)
+        ).first()
+
+
+def init_oauth(app):
+    global _oauth_configured
+    if _oauth_configured:
+        return
+
+    oauth.init_app(app, query_client=load_client, save_token=save_token)
+    oauth.register_grant(AuthorizationCodeGrant)
+    oauth.register_grant(RefreshTokenGrant)
+    require_oauth.register_token_validator(MyBearerTokenValidator())
+    _oauth_configured = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,12 @@
 gunicorn==25.3.0
 Flask>=3.1.3,<4.0.0
 Flask-MQTT>=1.3.0,<2.0.0
-Flask-OAuthlib==0.9.6
+authlib>=1.3.0,<2.0.0
 Flask-SQLAlchemy>=3.1.0,<4.0.0
 SQLAlchemy>=2.0.16,<3.0.0
 Werkzeug>=3.1.0,<4.0.0
 Jinja2>=3.1.2,<4.0.0
 itsdangerous>=2.2.0,<3.0.0
-six==1.14.0
 firebase_admin==6.5.0
 google-auth>=2.22.0
 PyMySQL==1.1.1

--- a/routes.py
+++ b/routes.py
@@ -4,6 +4,7 @@
 import logging
 from flask import Blueprint, current_app, request, jsonify, redirect, render_template, make_response, url_for
 from authlib.integrations.flask_oauth2 import current_token
+from authlib.oauth2.rfc6749 import OAuth2Error
 from flask_login import login_required, current_user
 from action_devices import onSync, report_state, request_sync, actions, rquery
 from my_oauth import get_current_user, oauth, require_oauth
@@ -51,8 +52,8 @@ def authorize():
     if request.method == 'GET':
         try:
             grant = oauth.get_consent_grant(end_user=user)
-        except Exception as exc:
-            logger.warning("Invalid oauth authorize request: %s", exc)
+        except OAuth2Error as exc:
+            logger.exception("OAuth consent grant error: %s", exc)
             return redirect('/')
 
         scope = grant.request.scope or ''
@@ -61,8 +62,8 @@ def authorize():
             client=grant.client,
             user=user,
             scopes=scope.split(),
-            response_type=request.args.get('response_type', 'code'),
-            state=request.args.get('state'),
+            response_type=grant.request.response_type,
+            state=grant.request.state,
         )
 
     confirm = request.form.get('confirm', 'no')

--- a/routes.py
+++ b/routes.py
@@ -3,11 +3,10 @@
 
 import logging
 from flask import Blueprint, current_app, request, jsonify, redirect, render_template, make_response, url_for
+from authlib.integrations.flask_oauth2 import current_token
 from flask_login import login_required, current_user
-from sqlalchemy import select
 from action_devices import onSync, report_state, request_sync, actions, rquery
-from models import Client, db
-from my_oauth import get_current_user, oauth
+from my_oauth import get_current_user, oauth, require_oauth
 from notifications import is_mqtt_connected
 
 logger = logging.getLogger(__name__)
@@ -39,38 +38,42 @@ def profile():
 
 
 @bp.route('/oauth/token', methods=['POST'])
-@oauth.token_handler
 def access_token():
-    return {'version': '0.1.0'}
+    return oauth.create_token_response()
 
 
-@bp.route('/oauth/authorize', methods=['GET', 'POST'])  # pyright: ignore[reportArgumentType]
-# Both GET (render consent page) and POST (handle form submission) are required
-# by the OAuth2 Authorization Code flow and the @oauth.authorize_handler decorator.
-@oauth.authorize_handler
-def authorize(*args, **kwargs):
+@bp.route('/oauth/authorize', methods=['GET', 'POST'])
+def authorize():
     user = get_current_user()
     if not user:
         return redirect('/')
+
     if request.method == 'GET':
-        client_id = kwargs.get('client_id')
-        client = db.session.scalars(
-            select(Client).filter_by(client_id=client_id)
-        ).first()
-        if client is None:
+        try:
+            grant = oauth.get_consent_grant(end_user=user)
+        except Exception as exc:
+            logger.warning("Invalid oauth authorize request: %s", exc)
             return redirect('/')
-        kwargs['client'] = client
-        kwargs['user'] = user
-        return render_template('authorize.html', **kwargs)
+
+        scope = grant.request.scope or ''
+        return render_template(
+            'authorize.html',
+            client=grant.client,
+            user=user,
+            scopes=scope.split(),
+            response_type=request.args.get('response_type', 'code'),
+            state=request.args.get('state'),
+        )
 
     confirm = request.form.get('confirm', 'no')
-    return confirm == 'yes'
+    grant_user = user if confirm == 'yes' else None
+    return oauth.create_authorization_response(grant_user=grant_user)
 
 
 @bp.route('/api/me')
-@oauth.require_oauth()
-def me(req):
-    user = req.user
+@require_oauth()
+def me():
+    user = current_token.user
     return jsonify(username=user.username)
 
 
@@ -119,7 +122,7 @@ def device_status(device_id):
     device = next((d for d in dev_req['devices'] if d['id'] == device_id), None)
     if not device:
         return redirect(url_for('routes.devices'))
-    
+
     # Get current states
     states = rquery(device_id)
     return render_template('device_status.html', device=device, states=states)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -126,7 +126,7 @@ class OAuthEndpointTests(unittest.TestCase):
         self.assertEqual(authorize_resp.status_code, 302)
 
         token_resp = self.client.post('/oauth/token', data={'grant_type': 'client_credentials'})
-        self.assertEqual(token_resp.status_code, 401)
+        self.assertIn(token_resp.status_code, (400, 401))
 
         me_resp = self.client.get('/api/me')
         self.assertEqual(me_resp.status_code, 401)


### PR DESCRIPTION
## Summary
- Replace deprecated Flask-OAuthlib with Authlib for OAuth server functionality.
- Update OAuth routes to Authlib flow (`/oauth/authorize`, `/oauth/token`, `/api/me`).
- Add Authlib-compatible helper methods on OAuth models (client/grant/token behavior helpers).
- Keep existing endpoint behavior stable for current app usage and templates.

## Changes
- Dependencies:
  - Remove `Flask-OAuthlib`
  - Add `authlib>=1.3.0,<2.0.0`
  - Remove legacy `six` direct pin
- OAuth core:
  - Migrate provider wiring to `AuthorizationServer` + `ResourceProtector`
  - Implement authorization code + refresh token grants
  - Add bearer token validator
- App wiring:
  - Replace `oauth.init_app(app)` with `init_oauth(app)`
  - Enable insecure transport only for non-production envs for local/test OAuth behavior
- Tests:
  - Keep OAuth smoke tests green with Authlib response behavior

## Validation
- `pip check` passed
- `pytest tests/ -q` passed (12 passed)
- Flake8 blocking gate passed (`E9,F63,F7,F82`)
- Path safety check passed
- Pylint error gate for `my_oauth.py` passed

## Risk & Rollback
- Risk: Medium (OAuth internals changed, endpoint contracts preserved)
- Rollback: Revert this PR to restore previous provider implementation

## Summary by Sourcery

Migrate the application’s OAuth2 implementation from Flask-OAuthlib to Authlib while preserving existing endpoint behavior.

New Features:
- Introduce Authlib-based AuthorizationServer and ResourceProtector for handling OAuth2 authorization and protected resources.
- Implement authorization code and refresh token grant flows along with a bearer token validator.
- Expose Authlib-compatible helper methods on client, grant, and token models to support validation, expiry checks, and scope handling.

Bug Fixes:
- Ensure safer handling of optional token fields and defaults when persisting OAuth tokens.

Enhancements:
- Refactor OAuth initialization into an idempotent init_oauth helper that wires Authlib grants and token validation to the Flask app.
- Update OAuth routes to use Authlib’s request/response handling while maintaining existing user flows and templates.
- Allow insecure HTTP transport for Authlib only in non-production environments to keep local and test OAuth usage working.

Build:
- Replace Flask-OAuthlib dependency with Authlib and drop the unused six dependency from requirements.

Tests:
- Relax OAuth smoke test expectations to account for Authlib’s error response codes while keeping route-level behavior validated.