### PR TITLE
fix: harden auth session and schema compatibility (Phase 3)

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 from flask import Flask, send_from_directory
 from flask_login import LoginManager
 from firebase_admin import credentials, initialize_app, get_app
+from sqlalchemy import inspect, text
 from auth import auth
 from models import User, db
 from my_oauth import init_oauth
@@ -106,7 +107,43 @@ def init_database_schema(flask_app: Flask) -> None:
     logger.info('DB Engine: %s', db_uri.split(':')[0] if db_uri else 'unknown')
     with flask_app.app_context():
         db.create_all()
+        _ensure_password_column_capacity()
     logger.info('Initialized the database.')
+
+
+def _ensure_password_column_capacity() -> None:
+    """Ensure legacy user.password columns can store modern Werkzeug hashes."""
+    inspector = inspect(db.engine)
+    table_names = set(inspector.get_table_names())
+    if 'user' not in table_names:
+        return
+
+    columns = {column['name']: column for column in inspector.get_columns('user')}
+    password_column = columns.get('password')
+    if not password_column:
+        return
+
+    current_length = getattr(password_column['type'], 'length', None)
+    if current_length is None or current_length >= 255:
+        return
+
+    dialect = db.engine.dialect.name
+    if dialect == 'postgresql':
+        alter_sql = 'ALTER TABLE "user" ALTER COLUMN password TYPE VARCHAR(255)'
+    elif dialect in {'mysql', 'mariadb'}:
+        alter_sql = 'ALTER TABLE `user` MODIFY COLUMN password VARCHAR(255)'
+    else:
+        logger.warning(
+            'Detected legacy password column length=%s on unsupported dialect=%s; '
+            'manual migration to VARCHAR(255) required.',
+            current_length,
+            dialect,
+        )
+        return
+
+    logger.info('Expanding user.password column from %s to 255.', current_length)
+    db.session.execute(text(alter_sql))
+    db.session.commit()
 
 
 @app.route('/uploads/<filename>')

--- a/my_oauth.py
+++ b/my_oauth.py
@@ -7,6 +7,7 @@ from authlib.integrations.flask_oauth2 import AuthorizationServer, ResourceProte
 from authlib.oauth2.rfc6749 import grants
 from authlib.oauth2.rfc6750 import BearerTokenValidator
 from flask import session
+from flask_login import current_user
 from sqlalchemy import select
 from models import db
 from models import Client, Token, Grant, User
@@ -24,6 +25,11 @@ def _utcnow_naive():
 
 
 def get_current_user():
+    # Prefer Flask-Login identity so OAuth consent works after normal login flow.
+    if current_user.is_authenticated:
+        return current_user
+
+    # Fallback for legacy session payloads.
     if 'id' in session:
         uid = session['id']
         user = db.session.get(User, uid)

--- a/routes.py
+++ b/routes.py
@@ -56,14 +56,15 @@ def authorize():
             logger.exception("OAuth consent grant error: %s", exc)
             return redirect('/')
 
-        scope = grant.request.scope or ''
+        request_payload = getattr(grant.request, 'payload', grant.request)
+        scope = getattr(request_payload, 'scope', '') or ''
         return render_template(
             'authorize.html',
             client=grant.client,
             user=user,
             scopes=scope.split(),
-            response_type=grant.request.response_type,
-            state=grant.request.state,
+            response_type=getattr(request_payload, 'response_type', None),
+            state=getattr(request_payload, 'state', None),
         )
 
     confirm = request.form.get('confirm', 'no')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,7 @@ os.environ['APP_ENV'] = 'development'
 
 from app import app as flask_app  # noqa: E402
 from app import allowed_file  # noqa: E402
-from models import db, User  # noqa: E402
+from models import db, User, Client  # noqa: E402
 from sqlalchemy import select  # used in cleanup queries
 
 
@@ -119,17 +119,89 @@ class AuthTests(unittest.TestCase):
 class OAuthEndpointTests(unittest.TestCase):
     def setUp(self):
         flask_app.config.update(TESTING=True)
+        with flask_app.app_context():
+            db.create_all()
         self.client = flask_app.test_client()
 
-    def test_oauth_routes_smoke(self):
+    def _create_oauth_user_and_client(self):
+        with flask_app.app_context():
+            user = User(
+                username='oauth-user',
+                email='oauth@example.com',
+                name='OAuth User',
+                password='test-password',
+            )
+            client = Client(
+                client_id='oauth-client-id',
+                client_secret='oauth-client-secret',
+                user=user,
+                _redirect_uris='http://localhost/callback',
+                _default_scopes='profile',
+            )
+            db.session.add_all([user, client])
+            db.session.commit()
+
+    def tearDown(self):
+        with flask_app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def test_authorize_redirects_without_session(self):
         authorize_resp = self.client.get('/oauth/authorize', follow_redirects=False)
         self.assertEqual(authorize_resp.status_code, 302)
+        self.assertTrue(authorize_resp.location.endswith('/'))
 
+    def test_authorize_invalid_request_redirects_when_logged_in(self):
+        self._create_oauth_user_and_client()
+
+        with self.client.session_transaction() as sess:
+            sess['_user_id'] = '1'
+
+        authorize_resp = self.client.get('/oauth/authorize', follow_redirects=False)
+        self.assertEqual(authorize_resp.status_code, 302)
+        self.assertTrue(authorize_resp.location.endswith('/'))
+
+    def test_authorize_valid_request_renders_consent_for_logged_in_user(self):
+        self._create_oauth_user_and_client()
+
+        with self.client.session_transaction() as sess:
+            sess['_user_id'] = '1'
+
+        authorize_resp = self.client.get(
+            '/oauth/authorize?response_type=code&client_id=oauth-client-id'
+            '&redirect_uri=http://localhost/callback&scope=profile&state=abc',
+            follow_redirects=False,
+        )
+        self.assertEqual(authorize_resp.status_code, 200)
+        body = authorize_resp.get_data(as_text=True)
+        self.assertIn('oauth-client-id', body)
+
+    def test_token_returns_error_json_for_unsupported_grant(self):
         token_resp = self.client.post('/oauth/token', data={'grant_type': 'client_credentials'})
-        self.assertIn(token_resp.status_code, (400, 401))
+        self.assertEqual(token_resp.status_code, 400)
+        self.assertTrue(token_resp.content_type.startswith('application/json'))
+        payload = token_resp.get_json()
+        self.assertIsInstance(payload, dict)
+        self.assertEqual(payload.get('error'), 'unsupported_grant_type')
 
+    def test_me_requires_authorization_header(self):
         me_resp = self.client.get('/api/me')
         self.assertEqual(me_resp.status_code, 401)
+        self.assertTrue(me_resp.content_type.startswith('application/json'))
+        payload = me_resp.get_json()
+        self.assertIsInstance(payload, dict)
+        self.assertEqual(payload.get('error'), 'missing_authorization')
+
+    def test_me_rejects_invalid_bearer_token(self):
+        me_resp = self.client.get(
+            '/api/me',
+            headers={'Authorization': 'Bearer not-a-valid-token'},
+        )
+        self.assertEqual(me_resp.status_code, 401)
+        self.assertTrue(me_resp.content_type.startswith('application/json'))
+        payload = me_resp.get_json()
+        self.assertIsInstance(payload, dict)
+        self.assertEqual(payload.get('error'), 'invalid_token')
 
 
 class DeviceEndpointTests(unittest.TestCase):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -123,7 +123,8 @@ class OAuthEndpointTests(unittest.TestCase):
             db.create_all()
         self.client = flask_app.test_client()
 
-    def _create_oauth_user_and_client(self):
+    @staticmethod
+    def _create_oauth_user_and_client():
         with flask_app.app_context():
             user = User(
                 username='oauth-user',


### PR DESCRIPTION
## Summary
- Fix OAuth authorization user resolution to work with Flask-Login authenticated sessions.
- Add runtime schema compatibility guard to ensure `user.password` can store modern Werkzeug hashes.
- Update OAuth authorize template payload access to avoid Authlib deprecation warnings.
- Expand OAuth endpoint regression coverage for authorize/token/me contracts.

## Problem Addressed
Registration/login and authorization flow could fail in real runtime environments when:
- OAuth authorize relied on legacy `session['id']` while Flask-Login uses `_user_id`.
- Existing databases had `user.password` sized too small for modern default password hashes.

## Changes
- `my_oauth.py`
  - `get_current_user()` now prefers Flask-Login `current_user` when authenticated, with legacy session fallback.
- `app.py`
  - Added startup/init-db compatibility check that expands `user.password` to `VARCHAR(255)` when legacy schemas are detected (PostgreSQL/MySQL).
- `routes.py`
  - Switched authorize template field extraction to request payload access to remove deprecated Authlib request field usage.
- `tests/test_app.py`
  - Added/expanded OAuth contract tests:
    - authorize redirect when unauthenticated
    - authorize behavior on invalid request while logged in
    - authorize consent page render for valid logged-in request
    - token unsupported grant JSON contract
    - `/api/me` missing/invalid bearer token contracts

## Validation
- `pip check` passed
- `pytest tests/ -q` passed (17 passed)
- Manual local runtime verification completed:
  - signup with new user
  - login with created account
  - authorized profile access

## Risk & Rollback
- Risk: low-to-medium (runtime guard is targeted and only executes when legacy schema is detected).
- Rollback: revert this PR commit to return to previous behavior.

## Summary by Sourcery

Harden OAuth authentication and schema compatibility while expanding contract-level test coverage.

Bug Fixes:
- Resolve current user resolution for OAuth flows to work with Flask-Login authenticated sessions.
- Ensure legacy user.password columns are expanded at startup to support modern password hash lengths on supported SQL dialects.
- Adjust OAuth authorize template payload access to avoid deprecated Authlib request field usage and ensure correct consent rendering.

Enhancements:
- Add a runtime database schema check that conditionally migrates the user.password column to VARCHAR(255) for PostgreSQL/MySQL installations.

Tests:
- Add end-to-end OAuth authorize flow tests for unauthenticated redirects, invalid requests while logged in, and consent rendering for valid logged-in requests.
- Tighten OAuth token endpoint tests to assert structured JSON error responses for unsupported grant types.
- Expand /api/me endpoint tests to validate JSON error contracts for missing or invalid bearer tokens.