### PR TITLE
chore: harden production schema compatibility (Phase 5)

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,10 +18,15 @@ from routes import bp
 logger = logging.getLogger(__name__)
 
 
+def _is_production_environment() -> bool:
+    """Return True when runtime environment is production-like."""
+    environment = os.getenv('APP_ENV', os.getenv('FLASK_ENV', 'development')).lower()
+    return environment in {'production', 'prod'}
+
+
 def _get_config_object() -> str:
     """Resolve config from explicit APP_ENV with FLASK_ENV fallback."""
-    environment = os.getenv('APP_ENV', os.getenv('FLASK_ENV', 'development')).lower()
-    if environment in {'production', 'prod'}:
+    if _is_production_environment():
         return 'config.ProductionConfig'
     return 'config.DevelopmentConfig'
 
@@ -52,7 +57,7 @@ def _init_firebase(flask_app: Flask) -> None:
 app = Flask(__name__, template_folder='templates')
 app.config.from_object(_get_config_object())
 
-if app.config.get('ENV') != 'production':
+if not _is_production_environment():
     # Authlib requires HTTPS by default; allow HTTP for local/dev/test only.
     os.environ.setdefault('AUTHLIB_INSECURE_TRANSPORT', '1')
 
@@ -128,22 +133,29 @@ def _ensure_password_column_capacity() -> None:
         return
 
     dialect = db.engine.dialect.name
-    if dialect == 'postgresql':
-        alter_sql = 'ALTER TABLE "user" ALTER COLUMN password TYPE VARCHAR(255)'
-    elif dialect in {'mysql', 'mariadb'}:
-        alter_sql = 'ALTER TABLE `user` MODIFY COLUMN password VARCHAR(255)'
-    else:
-        logger.warning(
+    alter_sql = _password_column_migration_sql(dialect)
+    if not alter_sql:
+        message = (
             'Detected legacy password column length=%s on unsupported dialect=%s; '
-            'manual migration to VARCHAR(255) required.',
-            current_length,
-            dialect,
+            'manual migration to VARCHAR(255) required.'
         )
+        if _is_production_environment():
+            raise RuntimeError(message % (current_length, dialect))
+        logger.warning(message, current_length, dialect)
         return
 
     logger.info('Expanding user.password column from %s to 255.', current_length)
     db.session.execute(text(alter_sql))
     db.session.commit()
+
+
+def _password_column_migration_sql(dialect: str):
+    """Return migration SQL for supported dialects, or None if unsupported."""
+    if dialect == 'postgresql':
+        return 'ALTER TABLE "user" ALTER COLUMN password TYPE VARCHAR(255)'
+    if dialect in {'mysql', 'mariadb'}:
+        return 'ALTER TABLE `user` MODIFY COLUMN password VARCHAR(255)'
+    return None
 
 
 @app.route('/uploads/<filename>')

--- a/app.py
+++ b/app.py
@@ -149,7 +149,7 @@ def _ensure_password_column_capacity() -> None:
     db.session.commit()
 
 
-def _password_column_migration_sql(dialect: str):
+def _password_column_migration_sql(dialect: str) -> Any:
     """Return migration SQL for supported dialects, or None if unsupported."""
     if dialect == 'postgresql':
         return 'ALTER TABLE "user" ALTER COLUMN password TYPE VARCHAR(255)'

--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 def _is_production_environment() -> bool:
     """Return True when runtime environment is production-like."""
-    environment = os.getenv('APP_ENV', os.getenv('FLASK_ENV', 'development')).lower()
+    environment = os.getenv('APP_ENV', os.getenv('FLASK_ENV', 'development')).strip().lower()
     return environment in {'production', 'prod'}
 
 
@@ -151,9 +151,10 @@ def _ensure_password_column_capacity() -> None:
 
 def _password_column_migration_sql(dialect: str) -> Any:
     """Return migration SQL for supported dialects, or None if unsupported."""
-    if dialect == 'postgresql':
+    normalized_dialect = (dialect or '').strip().lower()
+    if normalized_dialect == 'postgresql':
         return 'ALTER TABLE "user" ALTER COLUMN password TYPE VARCHAR(255)'
-    if dialect in {'mysql', 'mariadb'}:
+    if normalized_dialect in {'mysql', 'mariadb'}:
         return 'ALTER TABLE `user` MODIFY COLUMN password VARCHAR(255)'
     return None
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,6 +4,7 @@ import sys
 import os
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -13,6 +14,7 @@ os.environ['APP_ENV'] = 'development'
 
 from app import app as flask_app  # noqa: E402
 from app import allowed_file  # noqa: E402
+from app import _is_production_environment, _password_column_migration_sql  # noqa: E402
 from models import db, User, Client  # noqa: E402
 from sqlalchemy import select  # used in cleanup queries
 
@@ -85,6 +87,35 @@ class AllowedFileTest(unittest.TestCase):
         self.assertFalse(allowed_file(''))
         self.assertFalse(allowed_file('.'))
         self.assertFalse(allowed_file('.hidden'))
+
+
+class AppHardeningHelpersTest(unittest.TestCase):
+    def test_is_production_environment_true_for_production_values(self):
+        with patch.dict(os.environ, {'APP_ENV': 'production'}, clear=False):
+            self.assertTrue(_is_production_environment())
+        with patch.dict(os.environ, {'APP_ENV': 'prod'}, clear=False):
+            self.assertTrue(_is_production_environment())
+
+    def test_is_production_environment_false_for_development(self):
+        with patch.dict(os.environ, {'APP_ENV': 'development'}, clear=False):
+            self.assertFalse(_is_production_environment())
+
+    def test_password_column_migration_sql_for_supported_dialects(self):
+        self.assertEqual(
+            _password_column_migration_sql('postgresql'),
+            'ALTER TABLE "user" ALTER COLUMN password TYPE VARCHAR(255)',
+        )
+        self.assertEqual(
+            _password_column_migration_sql('mysql'),
+            'ALTER TABLE `user` MODIFY COLUMN password VARCHAR(255)',
+        )
+        self.assertEqual(
+            _password_column_migration_sql('mariadb'),
+            'ALTER TABLE `user` MODIFY COLUMN password VARCHAR(255)',
+        )
+
+    def test_password_column_migration_sql_for_unsupported_dialect(self):
+        self.assertIsNone(_password_column_migration_sql('sqlite'))
 
 
 class AuthTests(unittest.TestCase):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -130,34 +130,40 @@ class AppHardeningHelpersTest(unittest.TestCase):
     def test_password_column_migration_sql_for_unsupported_dialect(self):
         self.assertIsNone(_password_column_migration_sql('sqlite'))
 
-    def test_ensure_password_column_capacity_unsupported_dialect_raises_in_production(self):
+    @staticmethod
+    def test_ensure_password_column_capacity_unsupported_dialect_raises_in_production():
         mock_inspector = Mock()
         mock_inspector.get_table_names.return_value = ['user']
         mock_inspector.get_columns.return_value = [
             {'name': 'password', 'type': SimpleNamespace(length=100)}
         ]
 
-        with flask_app.app_context():
-            with patch('app.inspect', return_value=mock_inspector):
-                with patch.object(db.engine.dialect, 'name', 'unsupported_dialect'):
-                    with patch.dict(os.environ, {'APP_ENV': 'production'}, clear=False):
-                        with self.assertRaises(RuntimeError):
-                            _ensure_password_column_capacity()
+        with flask_app.app_context(), \
+                patch('app.inspect', return_value=mock_inspector), \
+                patch.object(db.engine.dialect, 'name', 'unsupported_dialect'), \
+                patch.dict(os.environ, {'APP_ENV': 'production'}, clear=False):
+            try:
+                _ensure_password_column_capacity()
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError('Expected RuntimeError for unsupported dialect in production')
 
-    def test_ensure_password_column_capacity_unsupported_dialect_warns_in_non_production(self):
+    @staticmethod
+    def test_ensure_password_column_capacity_unsupported_dialect_warns_in_non_production():
         mock_inspector = Mock()
         mock_inspector.get_table_names.return_value = ['user']
         mock_inspector.get_columns.return_value = [
             {'name': 'password', 'type': SimpleNamespace(length=100)}
         ]
 
-        with flask_app.app_context():
-            with patch('app.inspect', return_value=mock_inspector):
-                with patch.object(db.engine.dialect, 'name', 'unsupported_dialect'):
-                    with patch.dict(os.environ, {'APP_ENV': 'development'}, clear=False):
-                        with patch('app.logger.warning') as mock_warning:
-                            _ensure_password_column_capacity()
-                            mock_warning.assert_called()
+        with flask_app.app_context(), \
+                patch('app.inspect', return_value=mock_inspector), \
+                patch.object(db.engine.dialect, 'name', 'unsupported_dialect'), \
+                patch.dict(os.environ, {'APP_ENV': 'development'}, clear=False), \
+                patch('app.logger.warning') as mock_warning:
+            _ensure_password_column_capacity()
+            assert mock_warning.called
 
 
 class AuthTests(unittest.TestCase):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,8 +3,9 @@ import unittest
 import sys
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -14,7 +15,7 @@ os.environ['APP_ENV'] = 'development'
 
 from app import app as flask_app  # noqa: E402
 from app import allowed_file  # noqa: E402
-from app import _is_production_environment, _password_column_migration_sql  # noqa: E402
+from app import _ensure_password_column_capacity, _is_production_environment, _password_column_migration_sql  # noqa: E402
 from models import db, User, Client  # noqa: E402
 from sqlalchemy import select  # used in cleanup queries
 
@@ -100,6 +101,10 @@ class AppHardeningHelpersTest(unittest.TestCase):
         with patch.dict(os.environ, {'APP_ENV': 'development'}, clear=False):
             self.assertFalse(_is_production_environment())
 
+    def test_is_production_environment_trims_whitespace(self):
+        with patch.dict(os.environ, {'APP_ENV': '  Production  '}, clear=False):
+            self.assertTrue(_is_production_environment())
+
     def test_password_column_migration_sql_for_supported_dialects(self):
         self.assertEqual(
             _password_column_migration_sql('postgresql'),
@@ -113,9 +118,46 @@ class AppHardeningHelpersTest(unittest.TestCase):
             _password_column_migration_sql('mariadb'),
             'ALTER TABLE `user` MODIFY COLUMN password VARCHAR(255)',
         )
+        self.assertEqual(
+            _password_column_migration_sql('  PostgreSQL  '),
+            'ALTER TABLE "user" ALTER COLUMN password TYPE VARCHAR(255)',
+        )
+        self.assertEqual(
+            _password_column_migration_sql('MySQL'),
+            'ALTER TABLE `user` MODIFY COLUMN password VARCHAR(255)',
+        )
 
     def test_password_column_migration_sql_for_unsupported_dialect(self):
         self.assertIsNone(_password_column_migration_sql('sqlite'))
+
+    def test_ensure_password_column_capacity_unsupported_dialect_raises_in_production(self):
+        mock_inspector = Mock()
+        mock_inspector.get_table_names.return_value = ['user']
+        mock_inspector.get_columns.return_value = [
+            {'name': 'password', 'type': SimpleNamespace(length=100)}
+        ]
+
+        with flask_app.app_context():
+            with patch('app.inspect', return_value=mock_inspector):
+                with patch.object(db.engine.dialect, 'name', 'unsupported_dialect'):
+                    with patch.dict(os.environ, {'APP_ENV': 'production'}, clear=False):
+                        with self.assertRaises(RuntimeError):
+                            _ensure_password_column_capacity()
+
+    def test_ensure_password_column_capacity_unsupported_dialect_warns_in_non_production(self):
+        mock_inspector = Mock()
+        mock_inspector.get_table_names.return_value = ['user']
+        mock_inspector.get_columns.return_value = [
+            {'name': 'password', 'type': SimpleNamespace(length=100)}
+        ]
+
+        with flask_app.app_context():
+            with patch('app.inspect', return_value=mock_inspector):
+                with patch.object(db.engine.dialect, 'name', 'unsupported_dialect'):
+                    with patch.dict(os.environ, {'APP_ENV': 'development'}, clear=False):
+                        with patch('app.logger.warning') as mock_warning:
+                            _ensure_password_column_capacity()
+                            mock_warning.assert_called()
 
 
 class AuthTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Finalize production hardening for runtime environment and legacy password-schema compatibility.
- Add tests for environment detection and SQL dialect mapping helpers.

## Changes
- `app.py`
  - Added `_is_production_environment()` helper and reused it in config/runtime checks.
  - Added `_password_column_migration_sql(dialect)` helper to centralize supported SQL mapping.
  - Improved `_ensure_password_column_capacity()` behavior:
    - keeps auto-migration for supported dialects (PostgreSQL/MySQL/MariaDB)
    - raises a runtime error in production for unsupported dialect + legacy schema instead of silently continuing
    - keeps warning-only behavior outside production.
- `tests/test_app.py`
  - Added `AppHardeningHelpersTest` cases for:
    - production environment detection
    - supported/unsupported SQL mapping behavior.

## Validation
- `pytest tests/ -q` passed (25 passed)
- Pre-commit path safety check passed

## Risk
- Low: targeted hardening around existing startup schema compatibility logic; behavior changes are explicit and tested.

## Summary by Sourcery

Harden production runtime behavior around environment detection and legacy password column schema compatibility.

Enhancements:
- Introduce a shared helper for detecting production-like environments and reuse it across configuration and runtime checks.
- Centralize SQL dialect-specific password column migration statements in a dedicated helper and adjust legacy schema handling to error in production for unsupported dialects while remaining warning-only in non-production.

Tests:
- Add unit tests covering production environment detection and SQL dialect mapping for password column migrations.