### PR TITLE
Add MQTT connectivity diagnostics and startup logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,9 +69,16 @@ app.register_blueprint(auth, url_prefix='')
 
 # MQTT CONNECT
 try:
+    logger.info(
+        'Initializing MQTT broker at %s:%s (TLS=%s)',
+        app.config.get('MQTT_BROKER_URL'),
+        app.config.get('MQTT_BROKER_PORT'),
+        app.config.get('MQTT_TLS_ENABLED'),
+    )
     mqtt.init_app(app)
     mqtt.subscribe('+/notification')
     mqtt.subscribe('+/status')
+    logger.info('MQTT initialized; connected=%s', mqtt.connected)
 except Exception as e:
     logger.warning('MQTT initialization skipped: %s', e)
 

--- a/app.py
+++ b/app.py
@@ -78,7 +78,7 @@ try:
     mqtt.init_app(app)
     mqtt.subscribe('+/notification')
     mqtt.subscribe('+/status')
-    logger.info('MQTT initialized; connected=%s', mqtt.connected)
+    logger.info('MQTT initialized; connection lifecycle will be reported by on_connect/on_disconnect callbacks')
 except Exception as e:
     logger.warning('MQTT initialization skipped: %s', e)
 

--- a/notifications.py
+++ b/notifications.py
@@ -10,6 +10,16 @@ def is_mqtt_connected():
     return bool(getattr(mqtt, 'connected', False))
 
 
+@mqtt.on_connect()
+def handle_connect(_client, _userdata, flags, rc):
+    logger.info('Connected to MQTT broker; flags=%s, rc=%s', flags, rc)
+
+
+@mqtt.on_disconnect()
+def handle_disconnect(_client, _userdata, rc):
+    logger.warning('Disconnected from MQTT broker; rc=%s', rc)
+
+
 @mqtt.on_message()
 def handle_messages(_client, _userdata, message):
     logger.debug('Received message on topic %s: %s', message.topic, message.payload.decode())

--- a/notifications.py
+++ b/notifications.py
@@ -1,8 +1,31 @@
 import logging
+import threading
+from collections import deque
+from datetime import datetime, timezone
+
 from flask_mqtt import Mqtt
 
 logger = logging.getLogger(__name__)
 mqtt = Mqtt()
+
+mqtt_log_lock = threading.Lock()
+mqtt_log_entries = deque(maxlen=100)
+
+
+def _append_mqtt_log(topic, payload, status):
+    entry = {
+        'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC'),
+        'topic': topic,
+        'payload': payload,
+        'status': status,
+    }
+    with mqtt_log_lock:
+        mqtt_log_entries.appendleft(entry)
+
+
+def get_mqtt_logs():
+    with mqtt_log_lock:
+        return list(mqtt_log_entries)
 
 
 def is_mqtt_connected():
@@ -13,21 +36,24 @@ def is_mqtt_connected():
 @mqtt.on_connect()
 def handle_connect(_client, _userdata, flags, rc):
     logger.info('Connected to MQTT broker; flags=%s, rc=%s', flags, rc)
+    _append_mqtt_log('system', f'Connected (flags={flags}, rc={rc})', 'Connected')
 
 
 @mqtt.on_disconnect()
 def handle_disconnect(_client, _userdata, rc):
     if rc == 0:
         logger.info('MQTT broker disconnected cleanly; rc=%s', rc)
+        _append_mqtt_log('system', f'Disconnected cleanly (rc={rc})', 'Clean disconnect')
     else:
         logger.warning('MQTT broker disconnected unexpectedly; rc=%s', rc)
+        _append_mqtt_log('system', f'Unexpected disconnect (rc={rc})', 'Disconnected')
 
 
 @mqtt.on_message()
 def handle_messages(_client, _userdata, message):
-    logger.debug('Received message on topic %s: %s', message.topic, message.payload.decode())
-    if message == 'hi':
-        logger.debug('== THIS IS NOT JOKE NO HI HERE ==')
+    payload = message.payload.decode(errors='replace')
+    logger.debug('Received message on topic %s: %s', message.topic, payload)
+    _append_mqtt_log(message.topic, payload, 'Received')
 
 
 @mqtt.on_publish()

--- a/notifications.py
+++ b/notifications.py
@@ -11,6 +11,11 @@ mqtt = Mqtt()
 mqtt_log_lock = threading.Lock()
 mqtt_log_entries = deque(maxlen=100)
 
+# Statuses that represent a healthy/expected MQTT event.
+# `status_class` is derived from this set inside _append_mqtt_log so that
+# routes and templates never need to re-declare the mapping.
+POSITIVE_STATUSES = frozenset({'Connected', 'Received', 'Clean disconnect'})
+
 
 def _append_mqtt_log(topic, payload, status):
     """Store an MQTT monitor entry in-memory with newest entries first."""
@@ -19,6 +24,7 @@ def _append_mqtt_log(topic, payload, status):
         'topic': topic,
         'payload': payload,
         'status': status,
+        'status_class': 'status-pill--active' if status in POSITIVE_STATUSES else '',
     }
     with mqtt_log_lock:
         mqtt_log_entries.appendleft(entry)
@@ -38,7 +44,7 @@ def _decode_payload(payload):
     try:
         return payload.decode('utf-8')
     except UnicodeDecodeError:
-        logger.warning('MQTT payload contained non-UTF8 bytes; storing hex view')
+        logger.debug('MQTT payload contained non-UTF8 bytes; storing hex view')
         return payload.hex()
 
 

--- a/notifications.py
+++ b/notifications.py
@@ -49,39 +49,34 @@ def is_mqtt_connected():
 
 @mqtt.on_connect()
 def handle_connect(_client, _userdata, flags, rc):
-    try:
-        if rc == 0:
-            logger.info('Connected to MQTT broker; flags=%s, rc=%s', flags, rc)
-            _append_mqtt_log('system', f'Connected (flags={flags}, rc={rc})', 'Connected')
-            return
+    if rc == 0:
+        logger.info('Connected to MQTT broker; flags=%s, rc=%s', flags, rc)
+        _append_mqtt_log('system', f'Connected (flags={flags}, rc={rc})', 'Connected')
+        return
 
-        logger.error('MQTT connection failed; flags=%s, rc=%s', flags, rc)
-        _append_mqtt_log('system', f'Connection failed (flags={flags}, rc={rc})', 'Connection failed')
-    except Exception:
-        logger.exception('Failed to process MQTT connect callback')
+    logger.error('MQTT connection failed; flags=%s, rc=%s', flags, rc)
+    _append_mqtt_log(
+        'system',
+        f'Connection failed (flags={flags}, rc={rc})',
+        'Connection failed',
+    )
 
 
 @mqtt.on_disconnect()
 def handle_disconnect(_client, _userdata, rc):
-    try:
-        if rc == 0:
-            logger.info('MQTT broker disconnected cleanly; rc=%s', rc)
-            _append_mqtt_log('system', f'Disconnected cleanly (rc={rc})', 'Clean disconnect')
-        else:
-            logger.warning('MQTT broker disconnected unexpectedly; rc=%s', rc)
-            _append_mqtt_log('system', f'Unexpected disconnect (rc={rc})', 'Disconnected')
-    except Exception:
-        logger.exception('Failed to process MQTT disconnect callback')
+    if rc == 0:
+        logger.info('MQTT broker disconnected cleanly; rc=%s', rc)
+        _append_mqtt_log('system', f'Disconnected cleanly (rc={rc})', 'Clean disconnect')
+    else:
+        logger.warning('MQTT broker disconnected unexpectedly; rc=%s', rc)
+        _append_mqtt_log('system', f'Unexpected disconnect (rc={rc})', 'Disconnected')
 
 
 @mqtt.on_message()
 def handle_messages(_client, _userdata, message):
-    try:
-        payload = _decode_payload(message.payload)
-        logger.debug('Received message on topic %s: %s', message.topic, payload)
-        _append_mqtt_log(message.topic, payload, 'Received')
-    except Exception:
-        logger.exception('Failed to process MQTT message callback')
+    payload = _decode_payload(message.payload)
+    logger.debug('Received message on topic %s: %s', message.topic, payload)
+    _append_mqtt_log(message.topic, payload, 'Received')
 
 
 @mqtt.on_publish()

--- a/notifications.py
+++ b/notifications.py
@@ -17,7 +17,10 @@ def handle_connect(_client, _userdata, flags, rc):
 
 @mqtt.on_disconnect()
 def handle_disconnect(_client, _userdata, rc):
-    logger.warning('Disconnected from MQTT broker; rc=%s', rc)
+    if rc == 0:
+        logger.info('MQTT broker disconnected cleanly; rc=%s', rc)
+    else:
+        logger.warning('MQTT broker disconnected unexpectedly; rc=%s', rc)
 
 
 @mqtt.on_message()

--- a/notifications.py
+++ b/notifications.py
@@ -13,6 +13,7 @@ mqtt_log_entries = deque(maxlen=100)
 
 
 def _append_mqtt_log(topic, payload, status):
+    """Store an MQTT monitor entry in-memory with newest entries first."""
     entry = {
         'timestamp': datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC'),
         'topic': topic,
@@ -24,8 +25,21 @@ def _append_mqtt_log(topic, payload, status):
 
 
 def get_mqtt_logs():
+    """Return a snapshot of MQTT monitor entries.
+
+    A lock is used to prevent concurrent deque mutations while copying.
+    """
     with mqtt_log_lock:
         return list(mqtt_log_entries)
+
+
+def _decode_payload(payload):
+    """Decode MQTT payload as UTF-8, falling back to hex for binary bytes."""
+    try:
+        return payload.decode('utf-8')
+    except UnicodeDecodeError:
+        logger.warning('MQTT payload contained non-UTF8 bytes; storing hex view')
+        return payload.hex()
 
 
 def is_mqtt_connected():
@@ -35,25 +49,39 @@ def is_mqtt_connected():
 
 @mqtt.on_connect()
 def handle_connect(_client, _userdata, flags, rc):
-    logger.info('Connected to MQTT broker; flags=%s, rc=%s', flags, rc)
-    _append_mqtt_log('system', f'Connected (flags={flags}, rc={rc})', 'Connected')
+    try:
+        if rc == 0:
+            logger.info('Connected to MQTT broker; flags=%s, rc=%s', flags, rc)
+            _append_mqtt_log('system', f'Connected (flags={flags}, rc={rc})', 'Connected')
+            return
+
+        logger.error('MQTT connection failed; flags=%s, rc=%s', flags, rc)
+        _append_mqtt_log('system', f'Connection failed (flags={flags}, rc={rc})', 'Connection failed')
+    except Exception:
+        logger.exception('Failed to process MQTT connect callback')
 
 
 @mqtt.on_disconnect()
 def handle_disconnect(_client, _userdata, rc):
-    if rc == 0:
-        logger.info('MQTT broker disconnected cleanly; rc=%s', rc)
-        _append_mqtt_log('system', f'Disconnected cleanly (rc={rc})', 'Clean disconnect')
-    else:
-        logger.warning('MQTT broker disconnected unexpectedly; rc=%s', rc)
-        _append_mqtt_log('system', f'Unexpected disconnect (rc={rc})', 'Disconnected')
+    try:
+        if rc == 0:
+            logger.info('MQTT broker disconnected cleanly; rc=%s', rc)
+            _append_mqtt_log('system', f'Disconnected cleanly (rc={rc})', 'Clean disconnect')
+        else:
+            logger.warning('MQTT broker disconnected unexpectedly; rc=%s', rc)
+            _append_mqtt_log('system', f'Unexpected disconnect (rc={rc})', 'Disconnected')
+    except Exception:
+        logger.exception('Failed to process MQTT disconnect callback')
 
 
 @mqtt.on_message()
 def handle_messages(_client, _userdata, message):
-    payload = message.payload.decode(errors='replace')
-    logger.debug('Received message on topic %s: %s', message.topic, payload)
-    _append_mqtt_log(message.topic, payload, 'Received')
+    try:
+        payload = _decode_payload(message.payload)
+        logger.debug('Received message on topic %s: %s', message.topic, payload)
+        _append_mqtt_log(message.topic, payload, 'Received')
+    except Exception:
+        logger.exception('Failed to process MQTT message callback')
 
 
 @mqtt.on_publish()
@@ -64,13 +92,3 @@ def handle_publish(_client, _userdata, mid):
 @mqtt.on_subscribe()
 def handle_subscribe(_client, _userdata, mid, granted_qos):
     logger.debug('Subscription id %s granted with qos %s.', mid, granted_qos)
-
-
-@mqtt.on_topic('XXX/notification')
-def handle_mytopic(_client, _userdata, message):
-    logger.debug('Received message on topic %s: %s', message.topic, message.payload.decode())
-
-
-@mqtt.on_topic('ZZZ/notification')
-def handle_ztopic(_client, _userdata, message):
-    logger.debug('Received message on topic %s: %s', message.topic, message.payload.decode())

--- a/routes.py
+++ b/routes.py
@@ -9,7 +9,7 @@ from authlib.oauth2.rfc6749 import OAuth2Error
 from flask_login import login_required, current_user
 from action_devices import onSync, report_state, request_sync, actions, rquery
 from my_oauth import get_current_user, load_client, oauth, require_oauth
-from notifications import is_mqtt_connected
+from notifications import get_mqtt_logs, is_mqtt_connected
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +164,14 @@ def device_status(device_id):
 @bp.route('/mqtt')
 @login_required
 def mqtt_log():
-    return render_template('mqtt_log.html')
+    connected = is_mqtt_connected()
+    log_entries = get_mqtt_logs()
+    return render_template(
+        'mqtt_log.html',
+        broker_connected=connected,
+        tls_enabled=bool(current_app.config.get('MQTT_TLS_ENABLED', False)),
+        log_entries=log_entries,
+    )
 
 
 @bp.route('/smarthome', methods=['POST'])

--- a/routes.py
+++ b/routes.py
@@ -165,11 +165,18 @@ def device_status(device_id):
 @login_required
 def mqtt_log():
     connected = is_mqtt_connected()
-    log_entries = get_mqtt_logs()
+    positive_statuses = {'Received', 'Connected', 'Clean disconnect'}
+    log_entries = [
+        {
+            **entry,
+            'status_class': 'status-pill--active' if entry.get('status') in positive_statuses else '',
+        }
+        for entry in get_mqtt_logs()
+    ]
     return render_template(
         'mqtt_log.html',
         broker_connected=connected,
-        tls_enabled=bool(current_app.config.get('MQTT_TLS_ENABLED', False)),
+        tls_enabled=current_app.config.get('MQTT_TLS_ENABLED', False),
         log_entries=log_entries,
     )
 

--- a/routes.py
+++ b/routes.py
@@ -165,19 +165,11 @@ def device_status(device_id):
 @login_required
 def mqtt_log():
     connected = is_mqtt_connected()
-    positive_statuses = {'Received', 'Connected', 'Clean disconnect'}
-    log_entries = [
-        {
-            **entry,
-            'status_class': 'status-pill--active' if entry.get('status') in positive_statuses else '',
-        }
-        for entry in get_mqtt_logs()
-    ]
     return render_template(
         'mqtt_log.html',
         broker_connected=connected,
-        tls_enabled=current_app.config.get('MQTT_TLS_ENABLED', False),
-        log_entries=log_entries,
+        tls_enabled=bool(current_app.config.get('MQTT_TLS_ENABLED', False)),
+        log_entries=get_mqtt_logs(),
     )
 
 

--- a/templates/mqtt_log.html
+++ b/templates/mqtt_log.html
@@ -51,7 +51,7 @@
                         <td><code>{{ entry.topic }}</code></td>
                         <td><code>{{ entry.payload }}</code></td>
                         <td>
-                            <span class="status-pill {{ 'status-pill--active' if entry.status in ['Received', 'Connected', 'Clean disconnect'] else '' }}" style="font-size: 0.7rem;">{{ entry.status }}</span>
+                            <span class="status-pill {{ entry.status_class }}" style="font-size: 0.7rem;">{{ entry.status }}</span>
                         </td>
                     </tr>
                     {% else %}

--- a/templates/mqtt_log.html
+++ b/templates/mqtt_log.html
@@ -9,21 +9,23 @@
                 <h1>MQTT Monitor</h1>
                 <p>Real-time system communication and device telemetry log.</p>
             </div>
-            <div class="status-pill status-pill--active">Live Feed</div>
+            <div class="status-pill {{ 'status-pill--active' if broker_connected else '' }}">
+                {{ 'Live Feed' if broker_connected else 'Offline Feed' }}
+            </div>
         </div>
         
         <div class="stats-row">
             <div class="stat-item">
                 <svg class="stat-item__icon"><use xlink:href="#icon-wifi"></use></svg>
                 <div>
-                    <span class="stat-item__value">Connected</span>
+                    <span class="stat-item__value">{{ 'Connected' if broker_connected else 'Disconnected' }}</span>
                     <span class="stat-item__label">Broker Status</span>
                 </div>
             </div>
             <div class="stat-item">
                 <svg class="stat-item__icon"><use xlink:href="#icon-shield"></use></svg>
                 <div>
-                    <span class="stat-item__value">Encrypted</span>
+                    <span class="stat-item__value">{{ 'Encrypted' if tls_enabled else 'Unencrypted' }}</span>
                     <span class="stat-item__label">Security</span>
                 </div>
             </div>
@@ -43,25 +45,20 @@
                     </tr>
                 </thead>
                 <tbody id="mqtt-log-body">
-                    <!-- Sample technical entries to show design -->
+                    {% for entry in log_entries %}
                     <tr>
-                        <td>17:25:01</td>
-                        <td><code>living_room/light/status</code></td>
-                        <td><code>{"on": true, "bri": 80}</code></td>
-                        <td><span class="status-pill status-pill--active" style="font-size: 0.7rem;">Received</span></td>
+                        <td>{{ entry.timestamp }}</td>
+                        <td><code>{{ entry.topic }}</code></td>
+                        <td><code>{{ entry.payload }}</code></td>
+                        <td>
+                            <span class="status-pill {{ 'status-pill--active' if entry.status in ['Received', 'Connected', 'Clean disconnect'] else '' }}" style="font-size: 0.7rem;">{{ entry.status }}</span>
+                        </td>
                     </tr>
+                    {% else %}
                     <tr>
-                        <td>17:24:55</td>
-                        <td><code>kitchen/ac/notification</code></td>
-                        <td><code>{"temp": 22, "mode": "cool"}</code></td>
-                        <td><span class="status-pill status-pill--active" style="font-size: 0.7rem;">Received</span></td>
+                        <td colspan="4" class="text-center">No MQTT events available yet.</td>
                     </tr>
-                    <tr>
-                        <td>17:24:40</td>
-                        <td><code>bedroom/lock/status</code></td>
-                        <td><code>{"locked": true}</code></td>
-                        <td><span class="status-pill status-pill--active" style="font-size: 0.7rem;">Received</span></td>
-                    </tr>
+                    {% endfor %}
                 </tbody>
             </table>
         </div>

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,98 @@
+import unittest
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import routes
+from app import app as flask_app
+from notifications import (
+    _append_mqtt_log,
+    get_mqtt_logs,
+    handle_connect,
+    handle_disconnect,
+    handle_messages,
+    mqtt_log_entries,
+    mqtt_log_lock,
+)
+
+
+class NotificationsHandlersTest(unittest.TestCase):
+    def setUp(self):
+        with mqtt_log_lock:
+            mqtt_log_entries.clear()
+
+    def test_handle_connect_success_records_connected(self):
+        handle_connect(None, None, {'session present': 0}, 0)
+        logs = get_mqtt_logs()
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(logs[0]['status'], 'Connected')
+
+    def test_handle_connect_failure_records_error_state(self):
+        handle_connect(None, None, {'session present': 0}, 5)
+        logs = get_mqtt_logs()
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(logs[0]['status'], 'Connection failed')
+
+    def test_handle_disconnect_variants(self):
+        handle_disconnect(None, None, 0)
+        handle_disconnect(None, None, 7)
+        logs = get_mqtt_logs()
+        self.assertEqual(logs[0]['status'], 'Disconnected')
+        self.assertEqual(logs[1]['status'], 'Clean disconnect')
+
+    def test_handle_messages_binary_payload_falls_back_to_hex(self):
+        message = SimpleNamespace(topic='sensor/bytes', payload=b'\xff\xfeA')
+        handle_messages(None, None, message)
+        logs = get_mqtt_logs()
+        self.assertEqual(logs[0]['topic'], 'sensor/bytes')
+        self.assertEqual(logs[0]['payload'], 'fffe41')
+        self.assertEqual(logs[0]['status'], 'Received')
+
+    def test_log_buffer_keeps_latest_100_entries(self):
+        for idx in range(105):
+            _append_mqtt_log('topic', f'payload-{idx}', 'Received')
+
+        logs = get_mqtt_logs()
+        self.assertEqual(len(logs), 100)
+        self.assertEqual(logs[0]['payload'], 'payload-104')
+        self.assertEqual(logs[-1]['payload'], 'payload-5')
+
+
+class MqttRouteViewModelTest(unittest.TestCase):
+    def test_mqtt_route_renders_dynamic_context(self):
+        sample_logs = [
+            {
+                'timestamp': '2026-05-04 10:00:00 UTC',
+                'topic': 'system',
+                'payload': 'Connected',
+                'status': 'Connected',
+            },
+            {
+                'timestamp': '2026-05-04 10:01:00 UTC',
+                'topic': 'system',
+                'payload': 'Failed',
+                'status': 'Connection failed',
+            },
+        ]
+
+        with flask_app.test_request_context('/mqtt'):
+            with patch('routes.is_mqtt_connected', return_value=True), \
+                 patch('routes.get_mqtt_logs', return_value=sample_logs), \
+                 patch('routes.render_template', return_value='ok') as render_mock:
+                response = routes.mqtt_log.__wrapped__()
+
+        self.assertEqual(response, 'ok')
+        render_mock.assert_called_once()
+        args, kwargs = render_mock.call_args
+        self.assertEqual(args[0], 'mqtt_log.html')
+        self.assertTrue(kwargs['broker_connected'])
+        self.assertIsInstance(kwargs['tls_enabled'], bool)
+        self.assertEqual(kwargs['log_entries'][0]['status_class'], 'status-pill--active')
+        self.assertEqual(kwargs['log_entries'][1]['status_class'], '')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -63,18 +63,21 @@ class NotificationsHandlersTest(unittest.TestCase):
 
 class MqttRouteViewModelTest(unittest.TestCase):
     def test_mqtt_route_renders_dynamic_context(self):
+        # status_class is set by _append_mqtt_log; simulate what get_mqtt_logs returns.
         sample_logs = [
             {
                 'timestamp': '2026-05-04 10:00:00 UTC',
                 'topic': 'system',
                 'payload': 'Connected',
                 'status': 'Connected',
+                'status_class': 'status-pill--active',
             },
             {
                 'timestamp': '2026-05-04 10:01:00 UTC',
                 'topic': 'system',
                 'payload': 'Failed',
                 'status': 'Connection failed',
+                'status_class': '',
             },
         ]
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -78,11 +78,11 @@ class MqttRouteViewModelTest(unittest.TestCase):
             },
         ]
 
-        with flask_app.test_request_context('/mqtt'):
-            with patch('routes.is_mqtt_connected', return_value=True), \
-                 patch('routes.get_mqtt_logs', return_value=sample_logs), \
-                 patch('routes.render_template', return_value='ok') as render_mock:
-                response = routes.mqtt_log.__wrapped__()
+        with flask_app.test_request_context('/mqtt'), \
+             patch('routes.is_mqtt_connected', return_value=True), \
+             patch('routes.get_mqtt_logs', return_value=sample_logs), \
+             patch('routes.render_template', return_value='ok') as render_mock:
+            response = routes.mqtt_log.__wrapped__()
 
         self.assertEqual(response, 'ok')
         render_mock.assert_called_once()


### PR DESCRIPTION
This PR adds MQTT connectivity diagnostics for the HiveMQ broker setup. It logs broker initialization details and registers MQTT connect/disconnect event handlers so connection state is visible in application logs.

## Summary by Sourcery

Add in-memory MQTT event monitoring, expose broker connection and TLS status in the MQTT monitor view, and log broker initialization and connection lifecycle events.

New Features:
- Expose recent MQTT events via an in-memory log buffer accessible from the MQTT monitor route.
- Display MQTT broker connection and TLS security status in the MQTT monitor template.

Enhancements:
- Log MQTT broker initialization details and connection lifecycle events at application startup.
- Simplify MQTT topic-specific handlers and centralize message logging.
- Render MQTT monitor entries dynamically instead of using static sample rows.

Tests:
- Add unit tests covering MQTT notification handlers, log buffering behavior, and the MQTT monitor route view model.