### PR TITLE
Refactor: Cleanup legacy MQTT, username, and AGENT_USER_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Then, you need to export some environment variables that will be used by the app
 - `MQTT_PASSWORD`
 - `MQTT_TLS_ENABLED` (Boolean, e.g., 'True')
 - `API_KEY`
-- `AGENT_USER_ID` (Legacy fallback, now generally derived from user session)
 - `DATABASEURL` (Firebase Realtime Database URL)
 
 ## Features

--- a/action_devices.py
+++ b/action_devices.py
@@ -181,15 +181,14 @@ def rexecute(deviceId, parameters, user_id=None):
 def onSync(user_id=None, agent_user_id=None):
     try:
         resolved_user = _normalize_user_scope(user_id)
-        fallback = resolved_user or current_app.config.get('AGENT_USER_ID', 'test-user')
-        agent_user = str(agent_user_id if agent_user_id is not None else fallback)
+        agent_user = str(agent_user_id if agent_user_id is not None else resolved_user)
         return {
             "agentUserId": agent_user,
             "devices": rsync(resolved_user)
         }
     except Exception as e:
         logger.error("Error in onSync: %s", e)
-        return {"agentUserId": current_app.config.get('AGENT_USER_ID', 'test-user'), "devices": []}
+        return {"agentUserId": "unknown", "devices": []}
 
 
 def onQuery(body, user_id=None):
@@ -238,8 +237,7 @@ def onExecute(body, user_id=None):
 
 
 def commands(payload, deviceId, execCommand, params, user_id=None):
-    """ more clean code as was bedore.
-    dont remember how state ad parameters is used """
+    """Normalize and execute smart home commands on a specific device."""
     try:
         if execCommand == 'action.devices.commands.OnOff':
             if 'on' not in params:
@@ -336,7 +334,7 @@ def report_state(user_id=None):
         n = 10**19 + secrets.randbelow(9 * 10**19 + 1)
         report_state_file = {
             'requestId': str(n),
-            'agentUserId': user_id or current_app.config.get('AGENT_USER_ID', 'test-user'),
+            'agentUserId': user_id or "unknown",
             'payload': rstate(user_id),
         }
 

--- a/action_devices.py
+++ b/action_devices.py
@@ -5,7 +5,6 @@ import json
 import logging
 import requests
 import secrets
-from flask import current_app
 from notifications import mqtt
 from firebase_utils import (
     _normalize_user_scope,
@@ -14,6 +13,9 @@ from firebase_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Fallback identifier for cases where user scope cannot be determined
+UNKNOWN_USER_ID = "unknown"
 
 try:
     import ReportState as state
@@ -181,14 +183,14 @@ def rexecute(deviceId, parameters, user_id=None):
 def onSync(user_id=None, agent_user_id=None):
     try:
         resolved_user = _normalize_user_scope(user_id)
-        agent_user = str(agent_user_id if agent_user_id is not None else resolved_user)
+        agent_user = str(agent_user_id if agent_user_id is not None else (resolved_user or UNKNOWN_USER_ID))
         return {
             "agentUserId": agent_user,
             "devices": rsync(resolved_user)
         }
     except Exception as e:
         logger.error("Error in onSync: %s", e)
-        return {"agentUserId": "unknown", "devices": []}
+        return {"agentUserId": UNKNOWN_USER_ID, "devices": []}
 
 
 def onQuery(body, user_id=None):
@@ -334,7 +336,7 @@ def report_state(user_id=None):
         n = 10**19 + secrets.randbelow(9 * 10**19 + 1)
         report_state_file = {
             'requestId': str(n),
-            'agentUserId': user_id or "unknown",
+            'agentUserId': user_id or UNKNOWN_USER_ID,
             'payload': rstate(user_id),
         }
 

--- a/app.py
+++ b/app.py
@@ -62,7 +62,6 @@ if not _is_production_environment():
     os.environ.setdefault('AUTHLIB_INSECURE_TRANSPORT', '1')
 
 logger.info('ENV is set to: %s', app.config.get('ENV'))
-logger.info('Agent USER.ID: %s', app.config.get('AGENT_USER_ID'))
 
 app.register_blueprint(bp, url_prefix='')
 app.register_blueprint(auth, url_prefix='')
@@ -79,9 +78,6 @@ try:
     # New multi-tenant topic structure: {user_id}/{device_id}/{notification|status}
     mqtt.subscribe('+/+/notification')
     mqtt.subscribe('+/+/status')
-    # Keep legacy subscriptions for backward compatibility during migration
-    mqtt.subscribe('+/notification')
-    mqtt.subscribe('+/status')
     logger.info('MQTT initialized; connection lifecycle will be reported by on_connect/on_disconnect callbacks')
 except Exception as e:
     logger.warning('MQTT initialization skipped: %s', e)

--- a/config.py
+++ b/config.py
@@ -46,7 +46,6 @@ class Config:
     MQTT_TLS_ENABLED = environ.get('MQTT_TLS_ENABLED', 'False').lower() in ('1', 'true', 'yes', 'on')
     MQTT_TLS_VERSION = ssl.PROTOCOL_TLS_CLIENT if MQTT_TLS_ENABLED else None
     API_KEY = environ.get('API_KEY')
-    AGENT_USER_ID = environ.get('AGENT_USER_ID')
     DATABASEURL = environ.get('DATABASEURL')  # your Project database URL
     SERVICE_ACCOUNT_DATA = data
 

--- a/models.py
+++ b/models.py
@@ -8,7 +8,6 @@ db = SQLAlchemy()
 
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String(40), unique=True)  # this will be removed
     #
     email = db.Column(db.String(100), unique=True)
     password = db.Column(db.String(255))

--- a/routes.py
+++ b/routes.py
@@ -53,7 +53,6 @@ def _resolve_smarthome_user_scope(req):
     Preference order:
     1) request-level agentUserId
     2) authenticated web session user id
-    3) configured AGENT_USER_ID fallback
     """
     payload = req.get('payload', {}) if isinstance(req.get('payload'), dict) else {}
     agent_user_id = req.get('agentUserId') or payload.get('agentUserId')
@@ -71,9 +70,7 @@ def _resolve_smarthome_user_scope(req):
         user_id = str(current_user.id)
         return user_id, user_id
 
-    fallback = current_app.config.get('AGENT_USER_ID')
-    fallback_str = str(fallback).strip() if fallback is not None else ''
-    return (fallback_str or None), (fallback_str or 'test-user')
+    return None, None
 
 
 @bp.route('/')
@@ -148,7 +145,7 @@ def handle_authorize():
 @require_oauth()
 def me():
     user = current_token.user
-    return jsonify(username=user.username)
+    return jsonify(email=user.email)
 
 
 @bp.route('/sync')

--- a/templates/authorize.html
+++ b/templates/authorize.html
@@ -19,7 +19,7 @@
             </div>
             <div>
                 <span class="md-label">Authenticated User</span>
-                <p class="u-margin-top-1">{{ user.username }}</p>
+                <p class="u-margin-top-1">{{ user.email }}</p>
             </div>
         </div>
     </div>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -303,7 +303,7 @@ class OAuthEndpointTests(unittest.TestCase):
         self.assertEqual(me_resp.status_code, 200)
         me_payload = me_resp.get_json()
         self.assertIsInstance(me_payload, dict)
-        self.assertEqual(me_payload.get('email'), 'oauth@example.com')
+        self.assertEqual(me_payload, {"email": "oauth@example.com"})
 
     def test_authorize_deny_consent_redirects_with_access_denied(self):
         user_id = self._create_oauth_user_and_client()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -201,7 +201,6 @@ class OAuthEndpointTests(unittest.TestCase):
     def _create_oauth_user_and_client():
         with flask_app.app_context():
             user = User(
-                username='oauth-user',
                 email='oauth@example.com',
                 name='OAuth User',
                 password='test-password',
@@ -304,7 +303,7 @@ class OAuthEndpointTests(unittest.TestCase):
         self.assertEqual(me_resp.status_code, 200)
         me_payload = me_resp.get_json()
         self.assertIsInstance(me_payload, dict)
-        self.assertEqual(me_payload.get('username'), 'oauth-user')
+        self.assertEqual(me_payload.get('email'), 'oauth@example.com')
 
     def test_authorize_deny_consent_redirects_with_access_denied(self):
         user_id = self._create_oauth_user_and_client()

--- a/tests/test_multi_tenant.py
+++ b/tests/test_multi_tenant.py
@@ -117,5 +117,20 @@ class MultiTenantTest(unittest.TestCase):
         self.assertIn("system", topics)
         self.assertNotIn("2/d2/status", topics)
 
+    @patch('firebase_utils.FIREBASE_AVAILABLE', False)
+    def test_on_sync_without_fallback_no_user(self):
+        """Verify onSync returns 'unknown' when no user is resolved."""
+        response = onSync(user_id=None, agent_user_id=None)
+        self.assertEqual(response['agentUserId'], "unknown")
+        self.assertEqual(response['devices'], [])
+
+    def test_smarthome_resolution_without_fallback_no_user(self):
+        """Verify _resolve_smarthome_user_scope returns (None, None) when no user is found."""
+        from routes import _resolve_smarthome_user_scope
+        req = {"requestId": "req1", "inputs": []}
+        user_scope, agent_user_id = _resolve_smarthome_user_scope(req)
+        self.assertIsNone(user_scope)
+        self.assertIsNone(agent_user_id)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_multi_tenant.py
+++ b/tests/test_multi_tenant.py
@@ -6,7 +6,6 @@ from flask import Flask
 import os
 os.environ['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
 os.environ['APP_ENV'] = 'testing'
-os.environ['AGENT_USER_ID'] = 'test-fallback-user'
 
 from action_devices import onSync, actions
 from notifications import handle_messages, get_mqtt_logs, _append_mqtt_log
@@ -14,7 +13,6 @@ from notifications import handle_messages, get_mqtt_logs, _append_mqtt_log
 class MultiTenantTest(unittest.TestCase):
     def setUp(self):
         self.app = Flask(__name__)
-        self.app.config['AGENT_USER_ID'] = 'test-fallback-user'
         self.ctx = self.app.app_context()
         self.ctx.push()
 


### PR DESCRIPTION
## Overview
This PR removes legacy components identified during the cleanup phase to improve codebase maintainability and ensure strict multi-tenant isolation.

### Changes:
- **MQTT**: Removed legacy subscriptions (`+/notification`, `+/status`) in favor of user-separated topics.
- **Models**: Removed the deprecated `username` column from the `User` model.
- **Configuration**: Removed `AGENT_USER_ID` fallback logic and logging.
- **UI/API**: Updated OAuth authorization and `/api/me` to use `email` as the primary identifier.
- **Cleanup**: Removed irrelevant/confusing comments in `action_devices.py`.
- **Testing**: Updated the test suite to reflect these changes.

### Verification:
- Ran `make test`: All 43 tests passed.

## Summary by Sourcery

Remove legacy single-tenant fallbacks and identifiers in favor of user-scoped, email-based, multi-tenant behavior.

Enhancements:
- Simplify smart home user resolution and sync/report_state behavior by eliminating AGENT_USER_ID-based fallbacks and using explicit user scope only.
- Switch OAuth `/api/me` response and authorization template to use email as the primary user identifier instead of username.
- Remove legacy MQTT topic subscriptions tied to non–user-scoped topics and rely solely on multi-tenant topic structure.
- Drop the deprecated `username` field from the `User` model and related test/fixture usage, standardizing on email.

Documentation:
- Update README to remove the deprecated AGENT_USER_ID configuration option.

Tests:
- Update OAuth and multi-tenant tests to reflect email-based identity and the removal of AGENT_USER_ID fallback behavior.

Chores:
- Clean up confusing comments and redundant logging related to legacy agent user handling.