### PR TITLE
⚡ Bolt: Fix N+1 queries in action_devices.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Fix N+1 query]
+**Learning:** Fixed N+1 queries in `rstate` and `onQuery` by bulk fetching data instead of using `rquery` inside a loop.
+**Action:** Always check for repeated fetches in loops that can be optimized to a bulk fetch.

--- a/action_devices.py
+++ b/action_devices.py
@@ -73,16 +73,21 @@ def rstate(user_id=None):
         if not devices_data:
             return {"devices": {"states": {}}}
 
-        devices = list(devices_data.keys())
         payload = {
             "devices": {
                 "states": {}
             }
         }
-        for device in devices:
+        for device, raw_data in devices_data.items():
             device = str(device)
             logger.debug('Getting Device status from: %s', device)
-            state_data = rquery(device, user_id=user_id)
+
+            # Use pre-fetched state if available in snapshot, else fallback
+            if isinstance(raw_data, dict) and 'states' in raw_data:
+                state_data = raw_data['states']
+            else:
+                state_data = rquery(device, user_id=user_id)
+
             if state_data:
                 payload['devices']['states'][device] = state_data
             logger.debug('Device state: %s', state_data)
@@ -199,10 +204,24 @@ def onQuery(body, user_id=None):
         payload = {
             "devices": {},
         }
+
+        # Optimize: bulk fetch device states to avoid N+1 queries
+        devices_data = _get_scoped_snapshot(user_id) or {}
+
         for i in body['inputs']:
             for device in i['payload']['devices']:
                 deviceId = device['id']
-                data = rquery(deviceId, user_id=user_id)
+
+                # Try getting from cache first
+                data = None
+                raw_data = devices_data.get(deviceId)
+                if isinstance(raw_data, dict) and 'states' in raw_data:
+                    data = raw_data['states']
+
+                # Fallback to single fetch and validation logic in rquery
+                if data is None:
+                    data = rquery(deviceId, user_id=user_id)
+
                 payload['devices'][deviceId] = data
         return payload
     except Exception as e:


### PR DESCRIPTION
⚡ Bolt: Fix N+1 queries in action_devices.py

💡 What:
- Updated `rstate` and `onQuery` to fetch device states using a single bulk query (`_get_scoped_snapshot`) instead of making an individual `rquery` call per device within a loop.
- Maintained fallback to `rquery` if the bulk snapshot does not contain the necessary state data for a given device, ensuring robustness and safe handling.
- Ensured snapshot results are guarded against unexpected structure types.

🎯 Why:
- The previous implementation suffered from an N+1 query problem, leading to excessive backend load and latency when querying statuses for multiple devices at once.
- This bottleneck worsens as a user's device count grows, significantly impacting the responsiveness of the app and smart home integration.

📊 Impact:
- Transforms O(N) database reads into O(1) reads for retrieving the states of a user's devices.

🔬 Measurement:
- Run `make test` to verify changes did not break existing behavior.
- In production with a user with many devices, observe reduced latency and fewer database/Firebase calls when `rstate` and `onQuery` are hit.

---
*PR created automatically by Jules for task [11317866971927128392](https://jules.google.com/task/11317866971927128392) started by @DaTiC0*

## Summary by Sourcery

Reduce backend load by reusing bulk-fetched device state snapshots in device state handlers.

Bug Fixes:
- Avoid N+1 queries in rstate by using pre-fetched device snapshot data when available, falling back to individual rquery calls only when necessary.
- Avoid N+1 queries in onQuery by bulk fetching device states and reusing them across devices while preserving existing rquery-based validation as a fallback.

Documentation:
- Add a Bolt learning note describing the N+1 query fix and highlighting bulk fetch optimization as a best practice.